### PR TITLE
[codex] Plan memory-leak regression coverage before FrankenPHP worker mode

### DIFF
--- a/specs/autonomous/core-service-plan-memory-leak-worker-mode-1776003256/architecture.md
+++ b/specs/autonomous/core-service-plan-memory-leak-worker-mode-1776003256/architecture.md
@@ -114,6 +114,15 @@ Required endpoint matrix:
 This layer complements the endpoint matrix with tighter object-deallocation
 checks around specific shared-service flows.
 
+Shared memory-test support for Layers A and B must:
+
+- collect `memory_get_usage(true)` and `memory_get_peak_usage(true)` at stable
+  checkpoints,
+- record warm-up versus measured iteration boundaries,
+- format readable diagnostics that stay free of business payloads and customer
+  PII, matching the redaction posture already used by
+  `DomainEventMessageHandler`.
+
 Primary candidates:
 
 - `DomainEventMessageHandler` repeated happy path

--- a/specs/autonomous/core-service-plan-memory-leak-worker-mode-1776003256/architecture.md
+++ b/specs/autonomous/core-service-plan-memory-leak-worker-mode-1776003256/architecture.md
@@ -53,7 +53,7 @@ Introduce a small test-support layer responsible for:
 - collecting `memory_get_usage(true)` and `memory_get_peak_usage(true)`,
 - recording per-batch checkpoints,
 - running controlled GC checkpoints during calibration,
-- and formatting assertion failures with readable diagnostics.
+- and formatting assertion failures with readable, redacted diagnostics that exclude business payloads and customer PII.
 
 **Likely future location**
 

--- a/specs/autonomous/core-service-plan-memory-leak-worker-mode-1776003256/architecture.md
+++ b/specs/autonomous/core-service-plan-memory-leak-worker-mode-1776003256/architecture.md
@@ -1,0 +1,164 @@
+# Architecture: Memory-Leak Regression Coverage for Worker-Mode Readiness
+
+## Architecture Goal
+
+Design a repository-native testing strategy that detects memory-retention regressions in long-lived execution paths before FrankenPHP worker mode is enabled, while staying compatible with the current Symfony and `php-fpm` architecture.
+
+## Current-State Alignment
+
+- Runtime today: `php-fpm` + Caddy, not FrankenPHP.
+- Highest-fidelity current proxy for long-lived state reuse: async domain-event processing in Symfony Messenger worker-style execution.
+- Existing automation surfaces: PHPUnit, Behat, Bats, K6, GitHub Actions, and `make ci`.
+- Existing risk hotspots already visible in code: `DomainEventMessageHandler`, customer event subscribers, and their shared-service interactions for cache invalidation, logging, and metrics emission.
+
+## Key Architectural Decisions
+
+### 1. Use a Two-Layer Testing Strategy
+
+- **Layer A: deterministic async-worker memory regression**
+  This becomes the first blocking signal because it exercises a real long-lived execution path that already exists in the repository.
+- **Layer B: HTTP memory evidence for future worker mode**
+  This remains informational until FrankenPHP worker mode exists locally and in CI.
+
+### 2. Keep the First Blocking Signal Inside PHPUnit
+
+The first regression suite should live in the repository's PHP test stack so it can:
+
+- run in a single process,
+- sample memory directly with low orchestration overhead,
+- reuse existing test fixtures and stubs,
+- and integrate with current CI entrypoints without introducing a new critical dependency.
+
+### 3. Treat K6 as a Workload Driver, Not a Leak Detector
+
+K6 is valuable for repeated request workloads, but it cannot prove PHP worker memory retention by itself. It should be paired with external worker or container memory sampling and should begin as supporting evidence rather than the primary blocker.
+
+### 4. Calibrate Before Enforcing
+
+The implementation must separate:
+
+- scenario construction,
+- measurement mechanics,
+- baseline calibration,
+- and final blocking thresholds.
+
+That avoids brittle CI and lets the team validate noise levels before converting evidence into a gate.
+
+## Proposed Solution Components
+
+### A. Memory Sampling Utilities
+
+Introduce a small test-support layer responsible for:
+
+- collecting `memory_get_usage(true)` and `memory_get_peak_usage(true)`,
+- recording per-batch checkpoints,
+- running controlled GC checkpoints during calibration,
+- and formatting assertion failures with readable diagnostics.
+
+**Likely future location**
+
+- `tests/Integration/Memory/Support/` or a similarly isolated integration-test support namespace.
+
+### B. Async Worker-Path Regression Scenarios
+
+Implement deterministic loop-based scenarios around `DomainEventMessageHandler` with representative subscribers.
+
+**Initial coverage set**
+
+1. Happy-path event processing with cache invalidation and metrics emission.
+2. Failure-path subscriber execution that triggers logging and metric-failure handling.
+3. Metric-emission failure path to ensure resilience logic does not accumulate retained state.
+
+### C. HTTP-Oriented Memory Evidence
+
+Reuse existing request workloads later through:
+
+- a low-noise endpoint such as health check for baseline sampling,
+- and one mixed customer workload for serializer, cache, and logging churn.
+
+These scenarios should run only once a reliable worker or container memory sampler is defined for the target runtime path.
+
+### D. Makefile and CI Integration
+
+The future implementation should expose:
+
+- a dedicated Make target for the blocking async-worker memory suite,
+- an optional Make target for informational HTTP memory evidence,
+- and a GitHub Actions job strategy that keeps blocking and informational signals separate.
+
+## Scenario Design
+
+### Blocking Scenario Group 1: Async Happy Path
+
+- Repeatedly invoke `DomainEventMessageHandler` with representative event envelopes.
+- Use stable fixtures and identical iteration counts.
+- Assert that post-warmup retained memory growth stays within calibrated limits.
+
+### Blocking Scenario Group 2: Async Failure Path
+
+- Repeatedly execute scenarios that throw inside subscribers.
+- Repeatedly execute scenarios where metric emission fails after subscriber failure.
+- Validate that failure-path allocations do not produce monotonic retained growth.
+
+### Informational Scenario Group 3: HTTP Baseline
+
+- Drive repeated health-check requests.
+- Later add repeated mixed customer request sequences from existing K6 assets.
+- Sample worker or container RSS externally and compare against the async baseline and future FrankenPHP runs.
+
+## Measurement Model
+
+Every scenario should define:
+
+- warm-up iterations,
+- measured iterations,
+- sample interval,
+- memory metrics captured,
+- and assertion rule.
+
+### Recommended Signal Shape
+
+- Baseline memory before warm-up
+- Memory after warm-up
+- Periodic retained-memory checkpoints
+- Final retained memory delta
+- Peak memory during run
+
+### Recommended Assertion Style
+
+Prefer rules such as:
+
+- retained delta after warm-up stays below a calibrated ceiling,
+- no sustained upward slope beyond a calibrated tolerance,
+- and peak memory does not exceed a scenario-specific budget without returning to steady state.
+
+## Candidate Repository Touchpoints
+
+- `tests/Integration/` for the blocking memory-regression harness
+- `tests/Load/` for informational HTTP memory evidence reuse
+- `Makefile` for execution entrypoints
+- `.github/workflows/` for CI integration
+- `docs/` for developer execution and rollout guidance
+
+## Risks and Mitigations
+
+- **Risk:** CI flakiness from noisy absolute thresholds
+  **Mitigation:** calibrate first; prefer steady-state growth rules over one-shot numbers.
+
+- **Risk:** over-scoping the first implementation
+  **Mitigation:** make async-worker regression the only initial blocker and keep HTTP evidence informational.
+
+- **Risk:** false confidence from `php-fpm` request loops
+  **Mitigation:** explicitly document that HTTP baselines are comparison evidence, not sufficient proof of worker-mode readiness.
+
+- **Risk:** documentation drift around event-driven architecture
+  **Mitigation:** treat implementation code and tests as the source of truth during execution and update docs alongside the future implementation.
+
+## Recommended First Implementation Boundary
+
+The first implementation should end when the repository has:
+
+1. a blocking async-worker memory-regression suite,
+2. a documented measurement policy and calibration approach,
+3. Make and CI entrypoints for the blocking suite,
+4. and a defined informational path for future HTTP and FrankenPHP comparison.

--- a/specs/autonomous/core-service-plan-memory-leak-worker-mode-1776003256/architecture.md
+++ b/specs/autonomous/core-service-plan-memory-leak-worker-mode-1776003256/architecture.md
@@ -1,164 +1,251 @@
-# Architecture: Memory-Leak Regression Coverage for Worker-Mode Readiness
+# Architecture: FrankenPHP Worker Mode With Endpoint-Wide Memory-Safety Coverage
 
 ## Architecture Goal
 
-Design a repository-native testing strategy that detects memory-retention regressions in long-lived execution paths before FrankenPHP worker mode is enabled, while staying compatible with the current Symfony and `php-fpm` architecture.
+Define a safe migration path from `php-fpm` to FrankenPHP worker mode for this
+Symfony service, with memory-safety rules strong enough that long-running
+workers do not introduce request-to-request state contamination or unbounded
+memory growth.
 
 ## Current-State Alignment
 
-- Runtime today: `php-fpm` + Caddy, not FrankenPHP.
-- Highest-fidelity current proxy for long-lived state reuse: async domain-event processing in Symfony Messenger worker-style execution.
-- Existing automation surfaces: PHPUnit, Behat, Bats, K6, GitHub Actions, and `make ci`.
-- Existing risk hotspots already visible in code: `DomainEventMessageHandler`, customer event subscribers, and their shared-service interactions for cache invalidation, logging, and metrics emission.
+- Runtime today: `php-fpm` behind Caddy.
+- Test primitives today: PHPUnit 10.5, Symfony `KernelTestCase`,
+  API Platform `ApiTestCase`, BrowserKit client reuse with `disableReboot()`,
+  Behat, Schemathesis, K6, and GitHub Actions.
+- Data layer today: Doctrine MongoDB ODM.
+- Risk hotspots already visible in code:
+  cache-backed repositories, OpenAPI/serializer helpers, observability emitters,
+  `DomainEventMessageHandler`, and customer event subscribers.
 
-## Key Architectural Decisions
+## Target Runtime Model
 
-### 1. Use a Two-Layer Testing Strategy
+### Worker-Mode Request Lifecycle
 
-- **Layer A: deterministic async-worker memory regression**
-  This becomes the first blocking signal because it exercises a real long-lived execution path that already exists in the repository.
-- **Layer B: HTTP memory evidence for future worker mode**
-  This remains informational until FrankenPHP worker mode exists locally and in CI.
+FrankenPHP worker mode should be treated as:
 
-### 2. Keep the First Blocking Signal Inside PHPUnit
+1. boot Symfony once,
+2. keep the kernel and service container resident,
+3. handle many HTTP requests in the same worker,
+4. perform explicit post-request cleanup,
+5. call `gc_collect_cycles()` after each handled request,
+6. increment the handled-request counter,
+7. terminate and restart the worker when the MAX_REQUESTS-style fuse is reached
+   or when worker health checks fail.
 
-The first regression suite should live in the repository's PHP test stack so it can:
+This lifecycle is materially different from `php-fpm`, where process memory is
+discarded at the end of the request.
 
-- run in a single process,
-- sample memory directly with low orchestration overhead,
-- reuse existing test fixtures and stubs,
-- and integrate with current CI entrypoints without introducing a new critical dependency.
+### Worker-Loop Operational Requirements
 
-### 3. Treat K6 as a Workload Driver, Not a Leak Detector
+- The worker must finish request handling cleanly before cleanup runs.
+- Cleanup must not rely on process exit.
+- `gc_collect_cycles()` must run after each handled request in the worker loop.
+- A MAX_REQUESTS-style restart fuse must be configured conservatively for
+  staging and early production.
+- Worker restarts must be observable so the team can distinguish healthy fuse
+  behavior from instability caused by leaks.
 
-K6 is valuable for repeated request workloads, but it cannot prove PHP worker memory retention by itself. It should be paired with external worker or container memory sampling and should begin as supporting evidence rather than the primary blocker.
+## Service Design Rules
 
-### 4. Calibrate Before Enforcing
+Any service that survives across requests must follow these rules:
 
-The implementation must separate:
+- no unbounded request data retained in service properties,
+- no static caches without strict bounds and a reset strategy,
+- no user, session, request, response, entity, or document objects lingering in
+  singleton-like services,
+- no memoization without both bounds and explicit reset behavior,
+- no callbacks or closures that capture request-scoped objects unless their
+  lifetime is strictly bounded to the request.
 
-- scenario construction,
-- measurement mechanics,
-- baseline calibration,
-- and final blocking thresholds.
+## Symfony-Specific Design Constraints
 
-That avoids brittle CI and lets the team validate noise levels before converting evidence into a gate.
+### Reset Strategy
 
-## Proposed Solution Components
+- Services that may accumulate state between requests must implement
+  `ResetInterface`.
+- Their `reset()` method must clear all accumulated mutable state.
+- They must be wired so Symfony resets them between same-kernel requests through
+  the `kernel.reset` mechanism.
 
-### A. Memory Sampling Utilities
+### Risk Categories That Must Be Audited
 
-Introduce a small test-support layer responsible for:
+- custom caches and memoizers
+- serializer-heavy helpers and normalizers
+- Doctrine ODM state holders and helpers around `DocumentManager`
+- security and context helpers
+- long-lived SDK or infrastructure clients that can capture request-derived data
+- static registries
+- observability collectors or spies that accumulate arrays on properties
 
-- collecting `memory_get_usage(true)` and `memory_get_peak_usage(true)`,
-- recording per-batch checkpoints,
-- running controlled GC checkpoints during calibration,
-- and formatting assertion failures with readable, redacted diagnostics that exclude business payloads and customer PII.
+### Required Service-Audit Checklist
 
-**Likely future location**
+For every risky service:
 
-- `tests/Integration/Memory/Support/` or a similarly isolated integration-test support namespace.
+1. identify mutable properties,
+2. classify each property as per-request data, bounded cache, or leaked state,
+3. redesign the service or implement `reset()`,
+4. add leak-focused tests that prove the state is cleared.
 
-### B. Async Worker-Path Regression Scenarios
+## Test Architecture
 
-Implement deterministic loop-based scenarios around `DomainEventMessageHandler` with representative subscribers.
+### Layer A: Endpoint-Wide Same-Kernel HTTP Memory-Safety Suite
 
-**Initial coverage set**
+This is the primary CI safety net because FrankenPHP worker mode reuses the same
+application kernel across requests.
 
-1. Happy-path event processing with cache invalidation and metrics emission.
-2. Failure-path subscriber execution that triggers logging and metric-failure handling.
-3. Metric-emission failure path to ensure resilience logic does not accumulate retained state.
+Implementation shape:
 
-### C. HTTP-Oriented Memory Evidence
+- use `WebTestCase`-compatible clients (`ApiTestCase` in this repo),
+- call `disableReboot()` so the same kernel handles repeated requests,
+- cover the full documented REST and GraphQL inventory through a matrix-driven
+  suite,
+- assert that targeted flows do not retain unexpected objects or show
+  unexplained post-warmup growth.
 
-Reuse existing request workloads later through:
+Required endpoint matrix:
 
-- a low-noise endpoint such as health check for baseline sampling,
-- and one mixed customer workload for serializer, cache, and logging churn.
+- all documented REST endpoints,
+- all documented GraphQL queries,
+- all documented GraphQL mutations.
 
-These scenarios should run only once a reliable worker or container memory sampler is defined for the target runtime path.
+### Layer B: High-Risk Kernel-Level Leak Checks
 
-### D. Makefile and CI Integration
+This layer complements the endpoint matrix with tighter object-deallocation
+checks around specific shared-service flows.
 
-The future implementation should expose:
+Primary candidates:
 
-- a dedicated Make target for the blocking async-worker memory suite,
-- an optional Make target for informational HTTP memory evidence,
-- and a GitHub Actions job strategy that keeps blocking and informational signals separate.
+- `DomainEventMessageHandler` repeated happy path
+- subscriber failure path
+- metrics-emission failure path
+- cache-backed repository interactions
+- serializer or normalization-heavy helpers
 
-## Scenario Design
+This layer should use `KernelTestCase` together with
+`ObjectDeallocationCheckerKernelTestCaseTrait`.
 
-### Blocking Scenario Group 1: Async Happy Path
+### Layer C: Deep Forensics
 
-- Repeatedly invoke `DomainEventMessageHandler` with representative event envelopes.
-- Use stable fixtures and identical iteration counts.
-- Assert that post-warmup retained memory growth stays within calibrated limits.
+`arnaud-lb/memprof` is the escalation path for:
 
-### Blocking Scenario Group 2: Async Failure Path
+- CI failures that are not well explained by object-retention assertions,
+- suspected native allocations,
+- staging or local runs where detailed heap forensics are required.
 
-- Repeatedly execute scenarios that throw inside subscribers.
-- Repeatedly execute scenarios where metric emission fails after subscriber failure.
-- Validate that failure-path allocations do not produce monotonic retained growth.
+`memprof` is intentionally optional/manual unless the repository later adds a
+dedicated workflow for it.
 
-### Informational Scenario Group 3: HTTP Baseline
+## Endpoint Scenario Design
 
-- Drive repeated health-check requests.
-- Later add repeated mixed customer request sequences from existing K6 assets.
-- Sample worker or container RSS externally and compare against the async baseline and future FrankenPHP runs.
+The endpoint-wide suite must include targeted repeated-request scenarios for:
 
-## Measurement Model
+- simple read endpoint,
+- authenticated endpoint,
+- Doctrine-heavy write endpoint,
+- serializer or normalization-heavy endpoint,
+- error or exception path,
+- endpoint using custom caches or shared services.
 
-Every scenario should define:
+Because the repo does not obviously commit security firewall config today, the
+authenticated scenario remains a required implementation item with an explicit
+repo-level open question on which protected route should be used.
 
-- warm-up iterations,
-- measured iterations,
-- sample interval,
-- memory metrics captured,
-- and assertion rule.
+## `disableReboot()` Design Notes
 
-### Recommended Signal Shape
+- `disableReboot()` is required because reboot-per-request tests do not model a
+  reused kernel.
+- In this mode Symfony resets services tagged with `kernel.reset` instead of
+  rebuilding the whole container.
+- The test suite must therefore account for:
+  security token storage reset behavior,
+  Doctrine ODM identity/unit-of-work behavior,
+  any service whose correctness currently depends on full kernel reboot.
 
-- Baseline memory before warm-up
-- Memory after warm-up
-- Periodic retained-memory checkpoints
-- Final retained memory delta
-- Peak memory during run
+The design must prefer deliberate test-environment adjustments over naive reuse
+of existing functional tests.
 
-### Recommended Assertion Style
+## Tooling Choices
 
-Prefer rules such as:
+- Primary leak-testing package:
+  `shipmonk/memory-scanner`
+- Primary Symfony/PHPUnit integration:
+  `KernelTestCase` and `WebTestCase` plus
+  `ObjectDeallocationCheckerKernelTestCaseTrait`
+- Optional deep forensic tool:
+  `arnaud-lb/memprof`
+- Non-primary option:
+  `roave/no-leaks` is not the migration anchor
 
-- retained delta after warm-up stays below a calibrated ceiling,
-- no sustained upward slope beyond a calibrated tolerance,
-- and peak memory does not exceed a scenario-specific budget without returning to steady state.
+## Observability Requirements
 
-## Candidate Repository Touchpoints
+The runtime and rollout plan must observe:
 
-- `tests/Integration/` for the blocking memory-regression harness
-- `tests/Load/` for informational HTTP memory evidence reuse
-- `Makefile` for execution entrypoints
-- `.github/workflows/` for CI integration
-- `docs/` for developer execution and rollout guidance
+- per-worker RSS or equivalent process memory trend over repeated requests,
+- handled request counts per worker,
+- worker restart count and restart reason,
+- distinction between normal warm-up and unbounded growth.
+
+Interpretation rules:
+
+- warm-up is an initial increase that later plateaus,
+- problematic growth is continued upward slope after warm-up,
+- repeated early restarts caused by MAX_REQUESTS or instability are rollout
+  blockers until explained.
+
+## CI and Rollout Architecture
+
+### CI
+
+- Memory-safety tests are part of the FrankenPHP migration track.
+- CI must fail on confirmed retained-object leaks in targeted tests.
+- Failure artifacts must be redacted and structured.
+- Deep `memprof` runs stay optional/manual unless the repo later promotes them.
+
+### Staged Rollout Path
+
+1. spec rewrite
+2. service audit
+3. leak-focused test implementation
+4. staging soak and repeated-request verification
+5. production rollout with conservative MAX_REQUESTS
+6. tuning after evidence
+
+### Rollback Path
+
+If leak indicators appear, rollback must allow:
+
+- disabling worker mode,
+- falling back to non-worker execution or safer runtime configuration,
+- raising conservatism around restart settings only as a temporary safety fuse.
 
 ## Risks and Mitigations
 
-- **Risk:** CI flakiness from noisy absolute thresholds
-  **Mitigation:** calibrate first; prefer steady-state growth rules over one-shot numbers.
+- **Risk:** worker mode enabled before reset audit is complete
+  **Mitigation:** rollout is blocked until service audit and endpoint-wide leak
+  suite exist.
 
-- **Risk:** over-scoping the first implementation
-  **Mitigation:** make async-worker regression the only initial blocker and keep HTTP evidence informational.
+- **Risk:** false confidence from reboot-per-request tests
+  **Mitigation:** same-kernel tests must use `disableReboot()`.
 
-- **Risk:** false confidence from `php-fpm` request loops
-  **Mitigation:** explicitly document that HTTP baselines are comparison evidence, not sufficient proof of worker-mode readiness.
+- **Risk:** legacy or third-party leaks remain after initial fixes
+  **Mitigation:** conservative MAX_REQUESTS fuse plus staged rollout plus
+  rollback path.
 
-- **Risk:** documentation drift around event-driven architecture
-  **Mitigation:** treat implementation code and tests as the source of truth during execution and update docs alongside the future implementation.
+- **Risk:** diagnostics leak payload or customer data
+  **Mitigation:** mirror the existing `DomainEventMessageHandler` policy and keep
+  failure evidence redacted.
 
-## Recommended First Implementation Boundary
+- **Risk:** numeric limits are invented before stable baselines exist
+  **Mitigation:** baseline measurement comes before any hard threshold.
 
-The first implementation should end when the repository has:
+## Recommended Implementation Boundary
 
-1. a blocking async-worker memory-regression suite,
-2. a documented measurement policy and calibration approach,
-3. Make and CI entrypoints for the blocking suite,
-4. and a defined informational path for future HTTP and FrankenPHP comparison.
+The first implementation phase is complete only when the repository has:
+
+1. a documented worker-loop cleanup contract,
+2. a mutable-service audit with reset decisions,
+3. a matrix-driven endpoint-wide same-kernel memory-safety suite design,
+4. supporting `KernelTestCase` leak checks for high-risk flows,
+5. CI/staging rollout rules, rollback rules, and restart observability
+   requirements.

--- a/specs/autonomous/core-service-plan-memory-leak-worker-mode-1776003256/epics.md
+++ b/specs/autonomous/core-service-plan-memory-leak-worker-mode-1776003256/epics.md
@@ -1,118 +1,189 @@
-# Epics and Stories: Memory-Leak Regression Coverage for Worker-Mode Readiness
+# Epics and Stories: FrankenPHP Worker Mode and Memory-Safety Rollout
 
 ## Requirements Coverage Map
 
-- `FR1`, `FR4`, `FR5`, `FR6`, `NFR1`, `NFR3`, `NFR4` → Epic 1
-- `FR2`, `FR3`, `NFR2`, `NFR6`, `NFR7` → Epic 2
-- `FR7`, `FR8`, `FR9`, `NFR5`, `NFR8` → Epic 3
+- `FR1`, `FR2`, `FR3`, `FR4`, `FR5`, `FR6`, `NFR3`, `NFR8` -> Epic 1
+- `FR7`, `FR8`, `FR9`, `FR10`, `FR11`, `FR12`, `FR13`, `FR14`, `NFR1`,
+  `NFR2`, `NFR4`, `NFR5` -> Epic 2
+- `FR15`, `FR16`, `FR17`, `NFR6`, `NFR7`, `NFR9` -> Epic 3
 
-## Epic 1: Establish the Memory-Regression Foundation
+## Epic 1: Lock the Worker-Mode Runtime Contract and Reset Strategy
 
-Goal: define the measurement policy and reusable harness primitives needed for deterministic leak-regression testing in a single PHP process.
+Goal: define how long-running workers are expected to behave and identify every
+service that can retain state between requests.
 
-### Story 1.1: Define Measurement Policy and Scenario Boundaries
+### Story 1.1: Audit the Service Container for Mutable Long-Lived State
 
-As a maintainer, I want a documented measurement policy for memory-regression tests so that future scenarios use the same warm-up, sampling, and threshold conventions.
-
-Acceptance criteria:
-
-- Warm-up behavior is explicitly separated from measured behavior.
-- The policy defines which memory signals are captured and how they are interpreted.
-- The policy explains how thresholds are calibrated before becoming blocking CI gates.
-- The policy names the first required async scenarios and the first informational HTTP scenarios.
-
-### Story 1.2: Add Reusable Memory Sampling Test Utilities
-
-As a developer, I want reusable test utilities for memory sampling and reporting so that each scenario does not reinvent measurement logic.
+As a maintainer, I want a concrete inventory of mutable long-lived services so
+that worker-mode risk is based on real code, not assumptions.
 
 Acceptance criteria:
 
-- A shared test-support utility can record baseline, periodic checkpoints, final retained delta, and peak memory.
-- Failure output is scenario-specific and readable in CI logs.
-- Utility behavior is deterministic enough for CI usage on Linux runners.
-- The utilities avoid exposing business payload details in diagnostics.
+- The audit identifies services that store arrays, entities, documents,
+  request-derived objects, closures, callbacks, or caches on properties.
+- The audit explicitly calls out risky categories:
+  custom caches, memoizers, serializer-heavy helpers, Doctrine ODM state
+  holders, security/context helpers, long-lived SDK clients, and static
+  registries.
+- The audit output distinguishes per-request state, bounded cache state, and
+  leaked state.
+- The audit references actual repository services or confirms when a category is
+  not present.
 
-### Story 1.3: Introduce a Single-Process Worker-Style Loop Harness
+### Story 1.2: Classify Risky Services and Define `ResetInterface` Actions
 
-As a developer, I want a loop-based execution harness for repeated async processing so that the test suite can simulate long-lived service reuse.
-
-Acceptance criteria:
-
-- The harness runs many iterations in one PHP process.
-- The harness supports warm-up iterations and measured iterations.
-- The harness can run both happy-path and failure-path scenarios.
-- The harness integrates with the repository's existing PHPUnit conventions.
-
-## Epic 2: Cover the Highest-Risk Memory-Retention Paths
-
-Goal: make the existing async domain-event path the first blocking regression signal for long-lived memory stability.
-
-### Story 2.1: Add Happy-Path Async Memory Regression Scenarios
-
-As a release owner, I want happy-path async event processing covered by memory-regression tests so that normal worker-style behavior is guarded before worker mode rollout.
+As a developer, I want a reset strategy for mutable services so that
+worker-mode behavior is explicit and testable.
 
 Acceptance criteria:
 
-- A scenario repeatedly executes `DomainEventMessageHandler` with representative envelopes.
-- The scenario includes real shared-service interactions such as cache invalidation or metrics emission.
-- The scenario enforces calibrated retained-memory expectations after warm-up.
-- The scenario is runnable locally and inside CI.
+- Each risky service is assigned one of: redesign, bounded cache, or
+  `ResetInterface`.
+- Services that keep mutable state between requests have an explicit `reset()`
+  expectation.
+- The plan documents how those services are wired into Symfony reset behavior.
+- The plan states which services should not be made resettable and instead must
+  be redesigned to stop holding request state.
 
-### Story 2.2: Add Failure-Path Async Memory Regression Scenarios
+### Story 1.3: Define the FrankenPHP Worker Loop Contract
 
-As a maintainer, I want repeated failure-path execution covered so that exceptions, logging, and resilience paths do not leak retained state.
-
-Acceptance criteria:
-
-- At least one scenario repeatedly triggers subscriber failure.
-- At least one scenario repeatedly triggers metric-emission failure handling.
-- Diagnostics clearly distinguish which failure path exceeded the allowed growth budget.
-- The suite proves that failure handling remains non-throwing while still checking memory behavior.
-
-### Story 2.3: Define Informational HTTP Memory Baseline Scenarios
-
-As a platform engineer, I want an HTTP-oriented baseline plan so that future FrankenPHP worker-mode behavior can be compared against request-shaped workloads.
+As a platform engineer, I want the worker loop behavior documented so that the
+runtime migration does not invent cleanup semantics during implementation.
 
 Acceptance criteria:
 
-- A low-noise HTTP scenario is defined for baseline comparison.
-- A mixed customer workload scenario is defined for higher-churn comparison.
-- The plan specifies external memory sampling requirements for these scenarios.
-- These scenarios are explicitly marked informational until the target worker runtime exists in the repository.
+- The worker lifecycle is documented as boot once, handle many requests, clean
+  up, call `gc_collect_cycles()`, and restart on a MAX_REQUESTS-style fuse.
+- The design states that MAX_REQUESTS is a safety fuse, not proof that leaks are
+  acceptable.
+- The design defines restart observability and rollback expectations.
+- The design describes how to distinguish normal warm-up from problematic growth.
 
-## Epic 3: Operationalize the Signal for Local Use and CI
+## Epic 2: Build the Endpoint-Wide Memory-Safety Test Layer
 
-Goal: make the future implementation practical, reviewable, and usable as a worker-mode rollout gate.
+Goal: create a repeatable same-kernel test strategy that covers the full
+documented endpoint surface and the highest-risk shared-service flows.
 
-### Story 3.1: Expose Memory-Regression Execution Through Make and Docs
+### Story 2.1: Introduce Memory-Scanner Test Support
 
-As a contributor, I want documented Make targets for the memory-regression suite so that I can run the same signal locally that CI will use.
-
-Acceptance criteria:
-
-- The blocking async-worker suite has a dedicated Make entrypoint.
-- Any informational HTTP evidence path has a separate Make entrypoint.
-- Developer documentation explains prerequisites, expected runtime, and failure interpretation.
-- The docs explain why these tests are a prerequisite for FrankenPHP worker mode.
-
-### Story 3.2: Add CI Wiring and Artifact Capture Policy
-
-As a reviewer, I want CI integration for memory-regression evidence so that pull requests can surface worker-mode readiness information consistently.
+As a contributor, I want shared test support for leak detection so that memory
+assertions follow one repository-standard pattern.
 
 Acceptance criteria:
 
-- Blocking and informational jobs are separated by purpose.
-- The blocking async-worker suite fits the repository's CI duration budget.
-- The plan defines a minimum failure-evidence schema captured as JSON or NDJSON artifacts, optionally gzip-compressed when large, containing at least: timestamp, job name, git commit, worker or process identifier, test case id, scenario name, warm-up and measured iteration counts, baseline memory bytes, post-warmup memory bytes, final retained memory bytes, peak memory bytes, short failure reason, reproduction command, linked logs path, and calibration policy version; any optional allocator stats, heap snapshot paths, or core-dump references must also remain free of business payloads and customer PII.
-- The policy states when calibration runs are required, how thresholds are updated safely, and that failure artifacts are uploaded under a stable CI prefix such as `artifacts/memory-regression/<job>/<scenario>/` with a 14-day retention period.
+- `shipmonk/memory-scanner` is the planned primary dev dependency.
+- Test support is designed around `ObjectDeallocationCheckerKernelTestCaseTrait`
+  for Symfony/PHPUnit usage where applicable.
+- Failure diagnostics are redacted and CI-friendly.
+- Baseline measurement is explicitly separated from hard threshold enforcement.
 
-### Story 3.3: Define the Worker-Mode Rollout Gate
+### Story 2.2: Add Same-Kernel Repeated-Request Coverage for All REST and GraphQL Endpoints
 
-As a release owner, I want a clear rollout gate so that FrankenPHP worker mode is only enabled after memory-regression evidence is credible.
+As a release owner, I want repeated-request coverage for the full endpoint
+inventory so that worker-mode safety is not based on a handful of happy paths.
 
 Acceptance criteria:
 
-- The gate explicitly requires the blocking async-worker suite to be green.
-- The gate explicitly requires informational HTTP memory evidence to exist before final worker-mode enablement.
-- The gate names the unresolved environment assumptions that must be closed before rollout.
-- The gate points to the future implementation artifacts and comparison evidence needed for approval.
+- The plan defines a matrix-driven `WebTestCase` or `ApiTestCase` suite using
+  `disableReboot()`.
+- All documented REST endpoints are represented in the repeated-request matrix.
+- All documented GraphQL queries and mutations are represented in the repeated-
+  request matrix.
+- The design remains maintainable through data providers or generated fixtures
+  rather than bespoke test classes for every route.
+
+### Story 2.3: Add Targeted High-Risk Scenarios
+
+As a maintainer, I want dedicated high-risk scenarios so that the suite can
+catch the most likely worker-mode failures early.
+
+Acceptance criteria:
+
+- The plan includes scenarios for:
+  simple read,
+  authenticated flow,
+  Doctrine-heavy write,
+  serializer-heavy response,
+  error or exception path,
+  endpoint using custom caches or shared services.
+- The plan includes supporting `KernelTestCase` leak checks for
+  `DomainEventMessageHandler` and related subscriber paths.
+- The plan documents `disableReboot()` caveats for security token storage and
+  Doctrine ODM instead of assuming reboot-per-request semantics.
+- The plan states that repeated requests must not show unexplained retained
+  objects for the targeted flows.
+
+## Epic 3: Operationalize the Migration in CI, Staging, and Production
+
+Goal: turn the test strategy into a deployable rollout gate with clear rollback
+criteria.
+
+### Story 3.1: Add CI Wiring and Failure-Evidence Policy
+
+As a reviewer, I want CI to surface worker-mode safety regressions
+consistently so that rollout decisions are based on repeatable evidence.
+
+Acceptance criteria:
+
+- Memory-safety tests are planned as part of the FrankenPHP migration track.
+- CI is expected to fail on confirmed retained-object leaks in targeted tests.
+- The plan defines a minimum failure-evidence schema using JSON or NDJSON
+  artifacts, optionally gzip-compressed when large.
+- The failure-evidence policy is structured and reviewable:
+  - required fields:
+    timestamp, job name, git commit, worker or process identifier, test case id,
+    scenario name, warm-up and measured iteration counts, baseline memory bytes,
+    post-warmup memory bytes, final retained memory bytes, peak memory bytes,
+    short failure reason, reproduction command, linked logs path, calibration
+    policy version
+  - optional fields:
+    allocator stats, heap snapshot paths, core-dump references
+  - retention and safety:
+    artifacts are uploaded under a stable prefix such as
+    `artifacts/memory-regression/<job>/<scenario>/`,
+    remain free of business payloads and customer PII,
+    and keep a bounded retention period suitable for review
+
+### Story 3.2: Define the Staging Soak and Deep-Debug Path
+
+As a platform engineer, I want a staging verification path so that worker mode
+is proven under repeated requests before production rollout.
+
+Acceptance criteria:
+
+- The plan defines a staging soak phase after CI leak tests are in place.
+- The plan requires worker RSS or equivalent trend observation during soak.
+- `arnaud-lb/memprof` is documented as the escalation path for difficult leaks or
+  native-allocation questions.
+- Deep `memprof` runs remain optional/manual unless a later workflow promotes
+  them.
+
+### Story 3.3: Define Production Rollout and Rollback Criteria
+
+As a release owner, I want conservative rollout rules so that worker mode can
+be reverted quickly if real leak indicators appear.
+
+Acceptance criteria:
+
+- Early staging and production use conservative MAX_REQUESTS settings.
+- The plan explicitly blocks rollout on:
+  unbounded memory growth,
+  cross-request state bleed,
+  authentication or Doctrine corruption caused by improper resets,
+  repeated worker restarts caused by instability.
+- The plan defines rollback to non-worker mode or safer runtime configuration.
+- Later tuning is allowed only after evidence from staging and early production.
+
+## Implementation Backlog
+
+1. audit the service container for mutable singleton-like state
+2. classify risky services by per-request state, bounded cache, or leaked state
+3. introduce `ResetInterface` implementations or redesign services where needed
+4. add `shipmonk/memory-scanner`
+5. add `KernelTestCase` and `WebTestCase` memory-safety test support
+6. add repeated-request endpoint tests using `disableReboot()`
+7. document and implement worker-loop cleanup expectations, including
+   `gc_collect_cycles()`
+8. configure conservative MAX_REQUESTS for staging
+9. run soak verification and collect worker RSS/restart evidence
+10. review findings, update rollout criteria, and only then enable worker mode

--- a/specs/autonomous/core-service-plan-memory-leak-worker-mode-1776003256/epics.md
+++ b/specs/autonomous/core-service-plan-memory-leak-worker-mode-1776003256/epics.md
@@ -74,7 +74,8 @@ Acceptance criteria:
 - `shipmonk/memory-scanner` is the planned primary dev dependency.
 - Test support is designed around `ObjectDeallocationCheckerKernelTestCaseTrait`
   for Symfony/PHPUnit usage where applicable.
-- Failure diagnostics are redacted and CI-friendly.
+- Failure diagnostics are redacted and CI-friendly, with no business payloads or
+  customer PII in assertion output or stored artifacts.
 - Baseline measurement is explicitly separated from hard threshold enforcement.
 
 ### Story 2.2: Add Same-Kernel Repeated-Request Coverage for All REST and GraphQL Endpoints

--- a/specs/autonomous/core-service-plan-memory-leak-worker-mode-1776003256/epics.md
+++ b/specs/autonomous/core-service-plan-memory-leak-worker-mode-1776003256/epics.md
@@ -1,0 +1,118 @@
+# Epics and Stories: Memory-Leak Regression Coverage for Worker-Mode Readiness
+
+## Requirements Coverage Map
+
+- `FR1`, `FR4`, `FR5`, `NFR1`, `NFR3`, `NFR4` → Epic 1
+- `FR2`, `FR3`, `NFR2`, `NFR6`, `NFR7` → Epic 2
+- `FR7`, `FR8`, `FR9`, `NFR5`, `NFR8` → Epic 3
+
+## Epic 1: Establish the Memory-Regression Foundation
+
+Goal: define the measurement policy and reusable harness primitives needed for deterministic leak-regression testing in a single PHP process.
+
+### Story 1.1: Define Measurement Policy and Scenario Boundaries
+
+As a maintainer, I want a documented measurement policy for memory-regression tests so that future scenarios use the same warm-up, sampling, and threshold conventions.
+
+Acceptance criteria:
+
+- Warm-up behavior is explicitly separated from measured behavior.
+- The policy defines which memory signals are captured and how they are interpreted.
+- The policy explains how thresholds are calibrated before becoming blocking CI gates.
+- The policy names the first required async scenarios and the first informational HTTP scenarios.
+
+### Story 1.2: Add Reusable Memory Sampling Test Utilities
+
+As a developer, I want reusable test utilities for memory sampling and reporting so that each scenario does not reinvent measurement logic.
+
+Acceptance criteria:
+
+- A shared test-support utility can record baseline, periodic checkpoints, final retained delta, and peak memory.
+- Failure output is scenario-specific and readable in CI logs.
+- Utility behavior is deterministic enough for CI usage on Linux runners.
+- The utilities avoid exposing business payload details in diagnostics.
+
+### Story 1.3: Introduce a Single-Process Worker-Style Loop Harness
+
+As a developer, I want a loop-based execution harness for repeated async processing so that the test suite can simulate long-lived service reuse.
+
+Acceptance criteria:
+
+- The harness runs many iterations in one PHP process.
+- The harness supports warm-up iterations and measured iterations.
+- The harness can run both happy-path and failure-path scenarios.
+- The harness integrates with the repository's existing PHPUnit conventions.
+
+## Epic 2: Cover the Highest-Risk Memory-Retention Paths
+
+Goal: make the existing async domain-event path the first blocking regression signal for long-lived memory stability.
+
+### Story 2.1: Add Happy-Path Async Memory Regression Scenarios
+
+As a release owner, I want happy-path async event processing covered by memory-regression tests so that normal worker-style behavior is guarded before worker mode rollout.
+
+Acceptance criteria:
+
+- A scenario repeatedly executes `DomainEventMessageHandler` with representative envelopes.
+- The scenario includes real shared-service interactions such as cache invalidation or metrics emission.
+- The scenario enforces calibrated retained-memory expectations after warm-up.
+- The scenario is runnable locally and inside CI.
+
+### Story 2.2: Add Failure-Path Async Memory Regression Scenarios
+
+As a maintainer, I want repeated failure-path execution covered so that exceptions, logging, and resilience paths do not leak retained state.
+
+Acceptance criteria:
+
+- At least one scenario repeatedly triggers subscriber failure.
+- At least one scenario repeatedly triggers metric-emission failure handling.
+- Diagnostics clearly distinguish which failure path exceeded the allowed growth budget.
+- The suite proves that failure handling remains non-throwing while still checking memory behavior.
+
+### Story 2.3: Define Informational HTTP Memory Baseline Scenarios
+
+As a platform engineer, I want an HTTP-oriented baseline plan so that future FrankenPHP worker-mode behavior can be compared against request-shaped workloads.
+
+Acceptance criteria:
+
+- A low-noise HTTP scenario is defined for baseline comparison.
+- A mixed customer workload scenario is defined for higher-churn comparison.
+- The plan specifies external memory sampling requirements for these scenarios.
+- These scenarios are explicitly marked informational until the target worker runtime exists in the repository.
+
+## Epic 3: Operationalize the Signal for Local Use and CI
+
+Goal: make the future implementation practical, reviewable, and usable as a worker-mode rollout gate.
+
+### Story 3.1: Expose Memory-Regression Execution Through Make and Docs
+
+As a contributor, I want documented Make targets for the memory-regression suite so that I can run the same signal locally that CI will use.
+
+Acceptance criteria:
+
+- The blocking async-worker suite has a dedicated Make entrypoint.
+- Any informational HTTP evidence path has a separate Make entrypoint.
+- Developer documentation explains prerequisites, expected runtime, and failure interpretation.
+- The docs explain why these tests are a prerequisite for FrankenPHP worker mode.
+
+### Story 3.2: Add CI Wiring and Artifact Capture Policy
+
+As a reviewer, I want CI integration for memory-regression evidence so that pull requests can surface worker-mode readiness information consistently.
+
+Acceptance criteria:
+
+- Blocking and informational jobs are separated by purpose.
+- The blocking async-worker suite fits the repository's CI duration budget.
+- The plan defines what memory evidence should be stored or logged on failure.
+- The policy states when calibration runs are required and how thresholds are updated safely.
+
+### Story 3.3: Define the Worker-Mode Rollout Gate
+
+As a release owner, I want a clear rollout gate so that FrankenPHP worker mode is only enabled after memory-regression evidence is credible.
+
+Acceptance criteria:
+
+- The gate explicitly requires the blocking async-worker suite to be green.
+- The gate explicitly requires informational HTTP memory evidence to exist before final worker-mode enablement.
+- The gate names the unresolved environment assumptions that must be closed before rollout.
+- The gate points to the future implementation artifacts and comparison evidence needed for approval.

--- a/specs/autonomous/core-service-plan-memory-leak-worker-mode-1776003256/epics.md
+++ b/specs/autonomous/core-service-plan-memory-leak-worker-mode-1776003256/epics.md
@@ -2,7 +2,7 @@
 
 ## Requirements Coverage Map
 
-- `FR1`, `FR4`, `FR5`, `NFR1`, `NFR3`, `NFR4` → Epic 1
+- `FR1`, `FR4`, `FR5`, `FR6`, `NFR1`, `NFR3`, `NFR4` → Epic 1
 - `FR2`, `FR3`, `NFR2`, `NFR6`, `NFR7` → Epic 2
 - `FR7`, `FR8`, `FR9`, `NFR5`, `NFR8` → Epic 3
 
@@ -103,8 +103,8 @@ Acceptance criteria:
 
 - Blocking and informational jobs are separated by purpose.
 - The blocking async-worker suite fits the repository's CI duration budget.
-- The plan defines what memory evidence should be stored or logged on failure.
-- The policy states when calibration runs are required and how thresholds are updated safely.
+- The plan defines a minimum failure-evidence schema captured as JSON or NDJSON artifacts, optionally gzip-compressed when large, containing at least: timestamp, job name, git commit, worker or process identifier, test case id, scenario name, warm-up and measured iteration counts, baseline memory bytes, post-warmup memory bytes, final retained memory bytes, peak memory bytes, short failure reason, reproduction command, linked logs path, and calibration policy version; any optional allocator stats, heap snapshot paths, or core-dump references must also remain free of business payloads and customer PII.
+- The policy states when calibration runs are required, how thresholds are updated safely, and that failure artifacts are uploaded under a stable CI prefix such as `artifacts/memory-regression/<job>/<scenario>/` with a 14-day retention period.
 
 ### Story 3.3: Define the Worker-Mode Rollout Gate
 

--- a/specs/autonomous/core-service-plan-memory-leak-worker-mode-1776003256/implementation-readiness.md
+++ b/specs/autonomous/core-service-plan-memory-leak-worker-mode-1776003256/implementation-readiness.md
@@ -1,4 +1,4 @@
-# Implementation Readiness: Memory-Leak Regression Coverage for Worker-Mode Readiness
+# Implementation Readiness: FrankenPHP Worker Mode and Memory-Safety Rollout
 
 ## Assessed Inputs
 
@@ -10,37 +10,60 @@
 
 ## Readiness Verdict
 
-Ready to begin implementation planning with two explicit guardrails.
+Ready to begin implementation planning for the migration track, but not ready to
+switch runtime until the service audit, endpoint-wide leak suite, and staging
+verification are complete.
 
 ## Why It Is Ready
 
-- The planning set is aligned on the primary goal: add memory-regression coverage before enabling FrankenPHP worker mode.
-- The plan deliberately avoids coupling the prerequisite testing work to the runtime migration itself.
-- The architecture and epics both prioritize the existing async worker-style path as the first blocking signal.
-- The PRD and epics both separate blocking regression coverage from later informational HTTP comparison evidence.
-- The bundle identifies concrete repository surfaces rather than describing worker-memory testing in generic terms.
+- The bundle now treats FrankenPHP worker mode as the target runtime rather than
+  a distant comparison point.
+- The runtime contract is explicit about post-request cleanup,
+  `gc_collect_cycles()`, and a MAX_REQUESTS-style restart fuse.
+- The plan names the full documented REST and GraphQL endpoint inventory as the
+  required same-kernel memory-safety matrix.
+- The plan gives implementation-level direction for `ResetInterface`,
+  `disableReboot()`, `ObjectDeallocationCheckerKernelTestCaseTrait`, and
+  `memprof`.
+- The rollout path is staged and includes CI, staging, production, and rollback
+  guardrails.
 
-## Required Guardrails Before Implementation Starts
+## Guardrails Before Runtime Enablement
 
-1. Approve the phased signal strategy:
-   the first merge-blocking implementation should cover async worker-style memory regression only, while HTTP memory evidence remains informational until FrankenPHP exists in the repo.
-2. Approve the calibration policy:
-   thresholds must be established from representative runners before becoming strict CI blockers.
+1. The mutable-service audit must be completed and reviewed.
+2. The endpoint-wide repeated-request suite must exist and be green.
+3. The authenticated endpoint scenario must be resolved with a real protected
+   path or an agreed test-safe substitute.
+4. Baseline measurement must be established before any numeric thresholds become
+   hard blockers.
+5. A staging soak path for long-running workers must be confirmed.
 
 ## Traceability Check
 
-- Research identifies the async domain-event path as the highest-fidelity current proxy.
-- The product brief turns that into a scoped, repository-specific prerequisite initiative.
-- The PRD converts the scope into measurable functional and non-functional requirements.
-- The architecture explains how the harness, scenario groups, and CI split satisfy those requirements.
-- The epics decompose the work into a logical implementation sequence that preserves the phased strategy.
+- Research grounds the plan in the current `php-fpm` runtime, existing test
+  primitives, and the documented endpoint inventory.
+- The product brief turns that research into a migration objective centered on
+  worker-mode safety rather than generic performance work.
+- The PRD converts the objective into concrete runtime, reset, testing, CI, and
+  rollout requirements.
+- The architecture explains how worker lifecycle rules, reset strategy, same-
+  kernel tests, and observability fit together.
+- The epics decompose the work into a sequence that can be implemented without
+  improvising the memory-safety strategy.
 
 ## Gaps and Warnings
 
-- Repository documentation around event-driven architecture lags behind the current code; implementation should reconcile docs as part of execution.
-- The eventual home for informational HTTP memory evidence in CI is still a policy decision, not a settled implementation detail.
-- Thresholds are intentionally not fixed yet; implementation must treat calibration as a first-class activity rather than an afterthought.
+- No committed FrankenPHP bootstrap exists yet, so implementation still needs to
+  confirm the final worker front-controller and runtime wiring.
+- The repo scan did not find committed security firewall configuration, so the
+  authenticated scenario remains unresolved.
+- Package compatibility for `shipmonk/memory-scanner` with the current
+  PHPUnit/Symfony stack still needs confirmation.
+- The repo documents load tests but does not obviously document a dedicated
+  worker-mode soak environment.
 
 ## Recommended First Story
 
-Start with **Epic 1, Story 1.1** to define the measurement policy, scenario list, and calibration rules. That story unlocks the harness and prevents later stories from encoding inconsistent memory assertions.
+Start with **Epic 1, Story 1.1** to audit the service container for mutable
+long-lived state. That story produces the concrete inventory needed to decide
+which services need `ResetInterface`, redesign, or special worker-mode tests.

--- a/specs/autonomous/core-service-plan-memory-leak-worker-mode-1776003256/implementation-readiness.md
+++ b/specs/autonomous/core-service-plan-memory-leak-worker-mode-1776003256/implementation-readiness.md
@@ -1,0 +1,46 @@
+# Implementation Readiness: Memory-Leak Regression Coverage for Worker-Mode Readiness
+
+## Assessed Inputs
+
+- [research.md](./research.md)
+- [product-brief.md](./product-brief.md)
+- [prd.md](./prd.md)
+- [architecture.md](./architecture.md)
+- [epics.md](./epics.md)
+
+## Readiness Verdict
+
+Ready to begin implementation planning with two explicit guardrails.
+
+## Why It Is Ready
+
+- The planning set is aligned on the primary goal: add memory-regression coverage before enabling FrankenPHP worker mode.
+- The plan deliberately avoids coupling the prerequisite testing work to the runtime migration itself.
+- The architecture and epics both prioritize the existing async worker-style path as the first blocking signal.
+- The PRD and epics both separate blocking regression coverage from later informational HTTP comparison evidence.
+- The bundle identifies concrete repository surfaces rather than describing worker-memory testing in generic terms.
+
+## Required Guardrails Before Implementation Starts
+
+1. Approve the phased signal strategy:
+   the first merge-blocking implementation should cover async worker-style memory regression only, while HTTP memory evidence remains informational until FrankenPHP exists in the repo.
+2. Approve the calibration policy:
+   thresholds must be established from representative runners before becoming strict CI blockers.
+
+## Traceability Check
+
+- Research identifies the async domain-event path as the highest-fidelity current proxy.
+- The product brief turns that into a scoped, repository-specific prerequisite initiative.
+- The PRD converts the scope into measurable functional and non-functional requirements.
+- The architecture explains how the harness, scenario groups, and CI split satisfy those requirements.
+- The epics decompose the work into a logical implementation sequence that preserves the phased strategy.
+
+## Gaps and Warnings
+
+- Repository documentation around event-driven architecture lags behind the current code; implementation should reconcile docs as part of execution.
+- The eventual home for informational HTTP memory evidence in CI is still a policy decision, not a settled implementation detail.
+- Thresholds are intentionally not fixed yet; implementation must treat calibration as a first-class activity rather than an afterthought.
+
+## Recommended First Story
+
+Start with **Epic 1, Story 1.1** to define the measurement policy, scenario list, and calibration rules. That story unlocks the harness and prevents later stories from encoding inconsistent memory assertions.

--- a/specs/autonomous/core-service-plan-memory-leak-worker-mode-1776003256/prd.md
+++ b/specs/autonomous/core-service-plan-memory-leak-worker-mode-1776003256/prd.md
@@ -1,0 +1,65 @@
+# Product Requirements Document: Memory-Leak Regression Testing for Worker-Mode Readiness
+
+## Overview
+
+This PRD defines the requirements for adding memory-leak regression coverage to core-service before FrankenPHP worker mode is enabled. The solution must create a reliable readiness signal for long-lived execution paths while fitting the repository's current Symfony, API Platform, DDD, CQRS, and CI conventions.
+
+## Background
+
+Core-service currently runs on `php-fpm`, which resets request state between requests. FrankenPHP worker mode will preserve application state across requests and can expose memory retention issues that current correctness tests do not detect. The repository already contains a worker-style execution path in async domain-event handling, making it the best current proxy for long-lived service reuse.
+
+## Goals
+
+- Detect memory-retention regressions before worker mode is introduced.
+- Start with deterministic worker-style scenarios that already exist in the codebase.
+- Define a staged path toward HTTP-oriented worker-mode evidence without requiring the runtime migration in the same change.
+- Make the future implementation runnable locally and automatable in CI.
+
+## Functional Requirements
+
+- `FR1`: The repository must provide a repeatable memory-regression harness that can execute many iterations in a single PHP process.
+- `FR2`: The first implementation must cover at least one happy-path async domain-event scenario using `DomainEventMessageHandler`.
+- `FR3`: The first implementation must cover at least one failure-path async domain-event scenario where subscriber execution or metric emission fails repeatedly.
+- `FR4`: The harness must distinguish warm-up behavior from measurement behavior and must not treat first-use allocations as leaks.
+- `FR5`: The harness must capture memory checkpoints across the run rather than only a final number.
+- `FR6`: The test output must clearly report scenario name, iteration counts, baseline memory, post-warmup samples, final memory, peak memory, and failure reason.
+- `FR7`: The repository must define a path for HTTP-oriented memory evidence so that future FrankenPHP worker-mode behavior can be compared against the baseline.
+- `FR8`: The repository must expose the future implementation through documented Makefile entrypoints and CI wiring.
+- `FR9`: The implementation plan must define which checks are blocking and which are informational during the initial rollout.
+
+## Non-Functional Requirements
+
+- `NFR1`: The first blocking suite must be deterministic enough to run in CI with low flake risk.
+- `NFR2`: Measurements must be reproducible on Linux-based Docker and GitHub Actions environments used by the repository.
+- `NFR3`: The memory-regression signal must favor steady-state growth analysis over a single absolute value.
+- `NFR4`: Thresholds must be calibrated on representative runners before becoming hard merge blockers.
+- `NFR5`: Test runtime must remain bounded so the suite can be adopted without materially destabilizing existing CI duration.
+- `NFR6`: Logs and test artifacts must avoid leaking business payloads or other sensitive data.
+- `NFR7`: The implementation must preserve existing architecture and quality standards and must not lower any CI thresholds.
+- `NFR8`: The design should prefer the simplest repository-native tools available before introducing new external tooling.
+
+## Assumptions
+
+- The team intends to enable FrankenPHP worker mode later, but not in this delivery.
+- Messenger worker-style execution is the best currently available proxy for long-lived process reuse.
+- Existing K6 assets are still useful, but only when paired with direct worker or container memory sampling.
+- The first implementation can phase black-box HTTP memory evidence after the deterministic async-worker suite is in place.
+
+## Dependencies
+
+- Existing PHPUnit infrastructure and repository test conventions.
+- Existing async domain-event path and customer event subscribers.
+- Future agreement on where HTTP-oriented memory sampling belongs in CI.
+
+## Out of Scope
+
+- Switching the runtime from `php-fpm` to FrankenPHP.
+- Tuning business logic or infrastructure solely for performance.
+- Reworking the general K6 load-test strategy beyond what memory evidence requires.
+
+## Acceptance Criteria
+
+1. A future implementation built from this PRD can add a blocking async-worker memory-regression suite without depending on FrankenPHP.
+2. The plan explicitly defines at least one future informational HTTP memory evidence path for later worker-mode comparison.
+3. The repository has a documented rollout policy that separates calibration from enforcement.
+4. The plan identifies concrete current code paths, harnesses, and CI integration points instead of describing leak testing generically.

--- a/specs/autonomous/core-service-plan-memory-leak-worker-mode-1776003256/prd.md
+++ b/specs/autonomous/core-service-plan-memory-leak-worker-mode-1776003256/prd.md
@@ -1,65 +1,156 @@
-# Product Requirements Document: Memory-Leak Regression Testing for Worker-Mode Readiness
+# Product Requirements Document: FrankenPHP Worker Mode and Endpoint-Wide Memory Safety
 
 ## Overview
 
-This PRD defines the requirements for adding memory-leak regression coverage to core-service before FrankenPHP worker mode is enabled. The solution must create a reliable readiness signal for long-lived execution paths while fitting the repository's current Symfony, API Platform, DDD, CQRS, and CI conventions.
+This PRD defines how core-service should move from `php-fpm` to FrankenPHP
+worker mode without introducing request-to-request state bleed or uncontrolled
+memory growth. The plan covers runtime design, service reset rules, endpoint-
+wide memory-safety tests, CI/staging rollout, and operational safeguards.
 
-## Background
+## Problem Statement
 
-Core-service currently runs on `php-fpm`, which resets request state between requests. FrankenPHP worker mode will preserve application state across requests and can expose memory retention issues that current correctness tests do not detect. The repository already contains a worker-style execution path in async domain-event handling, making it the best current proxy for long-lived service reuse.
+FrankenPHP worker mode is desirable because it avoids full Symfony bootstrap on
+every request, but it changes the application from a request-isolated PHP model
+to a long-running process model.
+
+Under worker mode, the application kernel, service container, caches, Doctrine
+ODM state, serializer state, and request-derived references may survive across
+requests. Traditional `php-fpm` assumptions are therefore no longer sufficient.
+
+The migration must explicitly prevent retained state, detect leaks early, and
+bound operational risk when code or third-party dependencies are not perfectly
+clean.
 
 ## Goals
 
-- Detect memory-retention regressions before worker mode is introduced.
-- Start with deterministic worker-style scenarios that already exist in the codebase.
-- Define a staged path toward HTTP-oriented worker-mode evidence without requiring the runtime migration in the same change.
-- Make the future implementation runnable locally and automatable in CI.
+- Safely adopt FrankenPHP worker mode for this Symfony service.
+- Prevent request-to-request state contamination in reused workers.
+- Detect memory leaks and retained objects early in CI and staging.
+- Cover the full documented REST and GraphQL endpoint inventory with memory-
+  safety tests.
+- Define a repeatable reset strategy for mutable services.
+- Keep the migration compatible with the repository's current Make, Docker,
+  PHPUnit, and GitHub Actions workflows.
+
+## Non-Goals
+
+- Guarantee mathematically perfect zero memory growth in every third-party
+  dependency.
+- Rewrite the whole application before the migration.
+- Treat MAX_REQUESTS as a substitute for fixing leaks.
+- Rely only on ad hoc manual profiling.
+- Position `roave/no-leaks` as the primary migration solution.
 
 ## Functional Requirements
 
-- `FR1`: The repository must provide a repeatable memory-regression harness that can execute many iterations in a single PHP process.
-- `FR2`: The first implementation must cover at least one happy-path async domain-event scenario using `DomainEventMessageHandler`.
-- `FR3`: The first implementation must cover at least one failure-path async domain-event scenario where subscriber execution or metric emission fails repeatedly.
-- `FR4`: The harness must distinguish warm-up behavior from measurement behavior and must not treat first-use allocations as leaks.
-- `FR5`: The harness must capture memory checkpoints across the run rather than only a final number.
-- `FR6`: The test output must clearly report scenario name, iteration counts, baseline memory, post-warmup samples, final memory, peak memory, and failure reason.
-- `FR7`: The repository must define a path for HTTP-oriented memory evidence so that future FrankenPHP worker-mode behavior can be compared against the baseline.
-- `FR8`: The repository must expose the future implementation through documented Makefile entrypoints and CI wiring.
-- `FR9`: The implementation plan must define which checks are blocking and which are informational during the initial rollout.
+- `FR1`: The architecture must define FrankenPHP worker mode as a boot-once,
+  handle-many-requests runtime model for core-service.
+- `FR2`: The worker-loop design must include explicit post-request cleanup and
+  `gc_collect_cycles()` after each handled request.
+- `FR3`: The runtime design must include a MAX_REQUESTS-style worker restart
+  fuse as a pragmatic safeguard for legacy or third-party leaks.
+- `FR4`: The implementation plan must require an audit of services that keep
+  mutable properties, arrays, entities, request-derived objects, closures,
+  callbacks, or caches on long-lived service instances.
+- `FR5`: Services that may retain state between requests must implement
+  `ResetInterface` and clear accumulated state in `reset()`, or be redesigned so
+  no mutable request state survives.
+- `FR6`: The plan must define service design rules that forbid unbounded request
+  data in service properties, unbounded static caches, and lingering
+  user/session/entity/request objects in singleton services.
+- `FR7`: The primary dev dependency for leak detection must be
+  `shipmonk/memory-scanner`.
+- `FR8`: The primary Symfony/PHPUnit integration path must use `KernelTestCase`
+  and `WebTestCase` leak checks with
+  `ObjectDeallocationCheckerKernelTestCaseTrait` where applicable.
+- `FR9`: The test strategy must include a dedicated memory-safety suite for all
+  currently documented REST endpoints.
+- `FR10`: The test strategy must include a dedicated memory-safety suite for all
+  currently documented GraphQL queries and mutations.
+- `FR11`: Endpoint-wide repeated-request tests must use same-kernel behavior via
+  `disableReboot()` so they approximate worker-mode reuse instead of reboot-per-
+  request behavior.
+- `FR12`: The plan must explicitly acknowledge that `disableReboot()` resets
+  `kernel.reset` services rather than rebuilding the container, and that test
+  environment adjustments may be required for security token storage and
+  Doctrine ODM behavior.
+- `FR13`: The test strategy must include targeted scenarios for:
+  simple read, authenticated flow, Doctrine-heavy write, serializer-heavy
+  response, error/exception path, and endpoints using custom caches or shared
+  services.
+- `FR14`: The plan must keep `DomainEventMessageHandler` and related subscriber
+  flows as supporting `KernelTestCase` leak scenarios because they also model
+  long-lived shared-service reuse.
+- `FR15`: CI must fail on confirmed retained-object leaks in targeted tests.
+- `FR16`: The plan must define an optional deep-debug path using
+  `arnaud-lb/memprof` for local or staging forensic analysis when CI leak tests
+  are inconclusive.
+- `FR17`: The plan must define staging rollout, production rollout, rollback,
+  and worker-restart observability expectations for the FrankenPHP migration.
 
 ## Non-Functional Requirements
 
-- `NFR1`: The first blocking suite must be deterministic enough to run in CI with low flake risk.
-- `NFR2`: Measurements must be reproducible on Linux-based Docker and GitHub Actions environments used by the repository.
-- `NFR3`: The memory-regression signal must favor steady-state growth analysis over a single absolute value.
-- `NFR4`: Thresholds must be calibrated on representative runners before becoming hard merge blockers.
-- `NFR5`: Test runtime must remain bounded so the suite can be adopted without materially destabilizing existing CI duration.
-- `NFR6`: Logs and test artifacts must avoid leaking business payloads or other sensitive data.
-- `NFR7`: The implementation must preserve existing architecture and quality standards and must not lower any CI thresholds.
-- `NFR8`: The design should prefer the simplest repository-native tools available before introducing new external tooling.
+- `NFR1`: The blocking memory-safety suite must be deterministic enough for CI.
+- `NFR2`: The strategy must work with the repository's Linux/Docker/GitHub
+  Actions execution model.
+- `NFR3`: Thresholds must not be invented. Baseline measurement must be
+  established first on representative runners.
+- `NFR4`: Failure diagnostics and artifacts must exclude business payloads and
+  customer PII.
+- `NFR5`: Endpoint-wide coverage must remain maintainable through a matrix-driven
+  test approach rather than ad hoc one-off tests.
+- `NFR6`: Existing quality thresholds must remain intact.
+- `NFR7`: The design must distinguish normal warm-up behavior from unbounded
+  growth.
+- `NFR8`: MAX_REQUESTS must be treated as a safety fuse, not as proof of worker
+  correctness.
+- `NFR9`: Deep `memprof` runs should remain optional/manual unless a later repo
+  workflow explicitly promotes them.
 
-## Assumptions
+## Endpoint Coverage Scope
 
-- The team intends to enable FrankenPHP worker mode later, but not in this delivery.
-- Messenger worker-style execution is the best currently available proxy for long-lived process reuse.
-- Existing K6 assets are still useful, but only when paired with direct worker or container memory sampling.
-- The first implementation can phase black-box HTTP memory evidence after the deterministic async-worker suite is in place.
+The initial endpoint matrix is the currently documented public surface:
 
-## Dependencies
+- REST: 19 routes covering health plus CRUD for customers, customer types, and
+  customer statuses
+- GraphQL: 15 operations covering read and write flows for the same domains
 
-- Existing PHPUnit infrastructure and repository test conventions.
-- Existing async domain-event path and customer event subscribers.
-- Future agreement on where HTTP-oriented memory sampling belongs in CI.
-
-## Out of Scope
-
-- Switching the runtime from `php-fpm` to FrankenPHP.
-- Tuning business logic or infrastructure solely for performance.
-- Reworking the general K6 load-test strategy beyond what memory evidence requires.
+The implementation may use data providers or generated fixtures to keep the
+suite maintainable, but the final matrix must represent the full documented
+surface.
 
 ## Acceptance Criteria
 
-1. A future implementation built from this PRD can add a blocking async-worker memory-regression suite without depending on FrankenPHP.
-2. The plan explicitly defines at least one future informational HTTP memory evidence path for later worker-mode comparison.
-3. The repository has a documented rollout policy that separates calibration from enforcement.
-4. The plan identifies concrete current code paths, harnesses, and CI integration points instead of describing leak testing generically.
+1. The specs explicitly describe the long-running worker constraints of
+   FrankenPHP worker mode.
+2. The worker-loop design explicitly requires post-request cleanup,
+   `gc_collect_cycles()`, and a MAX_REQUESTS-style restart fuse.
+3. The specs define a mandatory audit of risky stateful services and require
+   `ResetInterface` or redesign where mutable state survives across requests.
+4. The specs define a dedicated memory-safety test suite using
+   `shipmonk/memory-scanner` and
+   `ObjectDeallocationCheckerKernelTestCaseTrait`.
+5. The specs define repeated-request same-kernel tests for the full documented
+   REST and GraphQL endpoint inventory.
+6. The specs define targeted high-risk scenarios for simple read,
+   authenticated flow, Doctrine-heavy write, serializer-heavy response, error
+   path, and cache/shared-service flows.
+7. The specs explicitly document `disableReboot()` caveats for security token
+   storage and Doctrine ODM behavior.
+8. The specs document `memprof` as the escalation path for hard leaks.
+9. The specs define staged CI, staging, production rollout, and rollback
+   guardrails.
+10. No numeric leak threshold is claimed without a baseline measurement phase.
+
+## Assumptions / Open Questions
+
+- No committed FrankenPHP bootstrap or worker loop exists in the repo today.
+- The repository uses PHPUnit 10.5 and Symfony 7.4; package compatibility for
+  `shipmonk/memory-scanner` still needs confirmation during implementation.
+- The repo scan did not find committed security firewall config, so the concrete
+  authenticated endpoint for repeated-request leak testing still needs human
+  confirmation.
+- The repo documents load tests but does not obviously document a dedicated
+  worker-mode soak environment.
+- The initial service-audit results do not exist yet; the hotspots must be
+  discovered during implementation.

--- a/specs/autonomous/core-service-plan-memory-leak-worker-mode-1776003256/product-brief.md
+++ b/specs/autonomous/core-service-plan-memory-leak-worker-mode-1776003256/product-brief.md
@@ -1,0 +1,70 @@
+# Product Brief: Memory-Leak Regression Coverage Before FrankenPHP Worker Mode
+
+## Opportunity
+
+The core-service team wants to enable FrankenPHP worker mode in the future, but worker mode changes request lifecycle assumptions and increases the risk that retained state, caches, or service references leak memory across iterations. The repository already validates correctness through PHPUnit, Behat, and K6, yet it has no regression coverage for memory stability in long-lived execution paths.
+
+## Problem Statement
+
+Today, the service still runs on `php-fpm`, so memory is naturally reset between requests. That makes current HTTP correctness tests insufficient as a readiness signal for a persistent worker runtime. The repository does contain an existing long-lived execution proxy in Symfony Messenger workers, particularly in `DomainEventMessageHandler` and customer event subscribers, but the current tests only prove behavior and resilience, not steady-state memory usage.
+
+Without explicit regression coverage, worker mode could be enabled with hidden memory-retention defects that only appear under sustained traffic, increasing restart frequency, degrading throughput, and making rollback decisions reactive instead of evidence-driven.
+
+## Target Audience
+
+- Backend maintainers who will implement and own worker-mode readiness.
+- Platform and release owners who need a merge and rollout gate before enabling FrankenPHP worker mode.
+- Reviewers and operators who need credible, repeatable evidence that memory behavior is stable enough to proceed.
+
+## Desired Outcomes
+
+1. Establish a repository-native way to detect memory-retention regressions in long-lived execution paths.
+2. Cover the highest-risk current proxy path first: repeated async domain-event processing in worker-style execution.
+3. Prepare an HTTP-oriented comparison path that can later be used against FrankenPHP worker mode without requiring the migration in the first implementation.
+4. Define how the memory-regression evidence becomes runnable locally, visible in CI, and usable as a worker-mode rollout gate.
+
+## In Scope
+
+- Planning the deterministic test harnesses and scenarios needed for memory-regression coverage.
+- Defining measurement rules for warm-up, sampling cadence, and leak-detection assertions.
+- Selecting the first gating scenarios from current repository behavior.
+- Defining Makefile, CI, and reporting expectations for the future implementation.
+
+## Out of Scope
+
+- Enabling FrankenPHP worker mode.
+- Replacing the current `php-fpm` runtime.
+- General performance optimization unrelated to memory retention.
+- Broad load-testing redesign outside the needs of memory-regression evidence.
+
+## Success Metrics
+
+- The repository has a defined, repeatable memory-regression test strategy for long-lived execution paths before worker mode is introduced.
+- The first implementation plan covers at least one happy-path async scenario and one failure-path async scenario.
+- The team can run the same memory-regression suite locally and in CI with consistent measurement rules.
+- Future FrankenPHP rollout decisions can rely on an explicit evidence bundle instead of ad hoc debugging.
+
+## Constraints
+
+- The current repo does not yet run FrankenPHP, so the first gating signal must come from a high-fidelity proxy rather than the target runtime itself.
+- CI duration and flake budget must remain reasonable; heavyweight black-box memory testing cannot become a blind extension of the default test pipeline.
+- The project enforces strict CI and test-quality standards, so the future implementation must integrate without weakening thresholds.
+- Existing architecture docs lag behind code in some event-driven areas, so the plan should treat the running code and current tests as the primary source of truth.
+
+## Risks
+
+- Choosing only `php-fpm` request loops as the first signal would underrepresent worker-mode risk.
+- Treating K6 alone as a leak detector would produce noisy evidence without direct memory sampling.
+- Hard-coding thresholds before calibration would create brittle CI and false positives.
+- Adding a memory test plan that is too broad initially could delay adoption and reduce trust in the signal.
+
+## Product Decision
+
+The plan should intentionally ship in two layers:
+
+1. A deterministic, PHPUnit-based memory-regression harness for the existing async worker-style path as the first blocking safety net.
+2. An HTTP-oriented memory evidence path for future FrankenPHP comparison, initially informational until the target runtime exists in the repository.
+
+## Why Now
+
+Adding the regression coverage first de-risks the eventual worker-mode rollout and creates a stable baseline while the service is still on `php-fpm`. That makes the future runtime migration a controlled change with evidence, rather than a combined runtime-and-testing leap.

--- a/specs/autonomous/core-service-plan-memory-leak-worker-mode-1776003256/product-brief.md
+++ b/specs/autonomous/core-service-plan-memory-leak-worker-mode-1776003256/product-brief.md
@@ -1,70 +1,142 @@
-# Product Brief: Memory-Leak Regression Coverage Before FrankenPHP Worker Mode
+# Product Brief: Move Core Service From PHP-FPM to FrankenPHP Worker Mode Safely
 
 ## Opportunity
 
-The core-service team wants to enable FrankenPHP worker mode in the future, but worker mode changes request lifecycle assumptions and increases the risk that retained state, caches, or service references leak memory across iterations. The repository already validates correctness through PHPUnit, Behat, and K6, yet it has no regression coverage for memory stability in long-lived execution paths.
+Core Service can reduce bootstrap overhead and improve request efficiency by
+migrating from `php-fpm` to FrankenPHP worker mode. The value proposition is
+clear: keep the Symfony application booted, reuse the container, and stop paying
+full bootstrap cost on every request.
+
+The risk is equally clear: a reused Symfony kernel turns the application into a
+long-running PHP process. Mutable service state, Doctrine ODM references,
+serializer caches, log context, or third-party client state can leak across
+requests or grow without bound unless the migration is designed explicitly for
+worker semantics.
 
 ## Problem Statement
 
-Today, the service still runs on `php-fpm`, so memory is naturally reset between requests. That makes current HTTP correctness tests insufficient as a readiness signal for a persistent worker runtime. The repository does contain an existing long-lived execution proxy in Symfony Messenger workers, particularly in `DomainEventMessageHandler` and customer event subscribers, but the current tests only prove behavior and resilience, not steady-state memory usage.
+The current runtime model assumes request isolation because the application runs
+behind `php-fpm`. That assumption breaks under FrankenPHP worker mode.
 
-Without explicit regression coverage, worker mode could be enabled with hidden memory-retention defects that only appear under sustained traffic, increasing restart frequency, degrading throughput, and making rollback decisions reactive instead of evidence-driven.
+We therefore have two linked problems to solve in the same plan:
+
+1. adopt FrankenPHP worker mode as the target runtime model, and
+2. add endpoint-wide memory-safety coverage so request-to-request state
+   contamination and memory growth are caught before rollout.
+
+Correctness tests alone are not enough. Traditional request-isolated PHP
+assumptions are no longer sufficient.
+
+## Goals
+
+- Safely adopt FrankenPHP worker mode for this Symfony application.
+- Prevent request-to-request state contamination in long-lived workers.
+- Detect memory leaks and retained objects early in CI and staging.
+- Cover the full documented REST and GraphQL endpoint inventory with
+  repeated-request memory-safety tests.
+- Define operational safeguards for imperfect legacy code and third-party
+  dependencies.
+- Keep the design compatible with the repository's current Symfony, PHPUnit,
+  Docker, Make, and GitHub Actions workflows.
+
+## Non-Goals
+
+- Guarantee mathematically perfect zero memory growth in every dependency.
+- Rewrite the whole application before the migration.
+- Treat MAX_REQUESTS as the only solution to memory leaks.
+- Rely only on ad hoc manual profiling.
+- Make `roave/no-leaks` the primary worker-mode safety strategy.
 
 ## Target Audience
 
-- Backend maintainers who will implement and own worker-mode readiness.
-- Platform and release owners who need a merge and rollout gate before enabling FrankenPHP worker mode.
-- Reviewers and operators who need credible, repeatable evidence that memory behavior is stable enough to proceed.
-
-## Desired Outcomes
-
-1. Establish a repository-native way to detect memory-retention regressions in long-lived execution paths.
-2. Cover the highest-risk current proxy path first: repeated async domain-event processing in worker-style execution.
-3. Prepare an HTTP-oriented comparison path that can later be used against FrankenPHP worker mode without requiring the migration in the first implementation.
-4. Define how the memory-regression evidence becomes runnable locally, visible in CI, and usable as a worker-mode rollout gate.
+- Backend maintainers implementing the runtime migration and reset strategy
+- Platform and release owners deciding when worker mode is safe to enable
+- Reviewers who need concrete acceptance criteria before approving rollout
+- Operators who need observability and rollback criteria during staging and
+  production rollout
 
 ## In Scope
 
-- Planning the deterministic test harnesses and scenarios needed for memory-regression coverage.
-- Defining measurement rules for warm-up, sampling cadence, and leak-detection assertions.
-- Selecting the first gating scenarios from current repository behavior.
-- Defining Makefile, CI, and reporting expectations for the future implementation.
+- Rewriting the existing BMAD planning bundle so FrankenPHP worker mode is the
+  target architecture.
+- Defining the worker request lifecycle, cleanup requirements, and restart fuse.
+- Auditing mutable services and specifying `ResetInterface` requirements.
+- Defining an endpoint-wide memory-safety test layer for all current REST and
+  GraphQL operations.
+- Defining supporting `KernelTestCase` leak checks for high-risk service flows.
+- Defining CI, staging soak, rollout, and rollback policy for the migration.
 
 ## Out of Scope
 
-- Enabling FrankenPHP worker mode.
-- Replacing the current `php-fpm` runtime.
-- General performance optimization unrelated to memory retention.
-- Broad load-testing redesign outside the needs of memory-regression evidence.
+- Implementing the runtime migration in this change set
+- Rewriting unrelated application areas that are not needed for worker safety
+- Locking numeric leak thresholds before baseline measurements exist
+- Broad performance tuning unrelated to long-running-worker safety
 
 ## Success Metrics
 
-- The repository has a defined, repeatable memory-regression test strategy for long-lived execution paths before worker mode is introduced.
-- The first implementation plan covers at least one happy-path async scenario and one failure-path async scenario.
-- The team can run the same memory-regression suite locally and in CI with consistent measurement rules.
-- Future FrankenPHP rollout decisions can rely on an explicit evidence bundle instead of ad hoc debugging.
+- The BMAD bundle makes FrankenPHP worker mode a first-class architectural
+  constraint instead of a future afterthought.
+- The plan defines how every documented endpoint will be exercised under
+  same-kernel repeated-request tests.
+- The plan defines a concrete reset strategy for mutable services.
+- The plan defines CI/staging signals that can detect retained state before
+  production rollout.
+- The plan gives engineers enough structure to implement the migration without
+  inventing the memory-safety strategy from scratch.
 
 ## Constraints
 
-- The current repo does not yet run FrankenPHP, so the first gating signal must come from a high-fidelity proxy rather than the target runtime itself.
-- CI duration and flake budget must remain reasonable; heavyweight black-box memory testing cannot become a blind extension of the default test pipeline.
-- The project enforces strict CI and test-quality standards, so the future implementation must integrate without weakening thresholds.
-- Existing architecture docs lag behind code in some event-driven areas, so the plan should treat the running code and current tests as the primary source of truth.
+- The committed runtime is still `php-fpm` plus Caddy; FrankenPHP bootstrap is
+  not yet present.
+- The repository enforces strict quality gates, so the migration plan cannot
+  lower existing CI standards.
+- Endpoint-wide coverage must stay maintainable, which implies matrix-driven
+  test generation rather than bespoke one-off tests for every route.
+- Some repo-specific worker-mode details are still unresolved, especially the
+  concrete authenticated endpoint and the final worker bootstrap shape.
 
 ## Risks
 
-- Choosing only `php-fpm` request loops as the first signal would underrepresent worker-mode risk.
-- Treating K6 alone as a leak detector would produce noisy evidence without direct memory sampling.
-- Hard-coding thresholds before calibration would create brittle CI and false positives.
-- Adding a memory test plan that is too broad initially could delay adoption and reduce trust in the signal.
+- Migrating runtime before leak coverage exists would make production the first
+  long-running-process test.
+- Adding worker mode without a reset audit could allow cross-request bleed in
+  caches, Doctrine state, or serializer-heavy services.
+- Using only MAX_REQUESTS could hide real leaks until load increases.
+- Using only manual profiling would make regression detection inconsistent and
+  reviewer-dependent.
+- Treating K6 alone as the leak detector would miss object-retention issues that
+  require PHP-level assertions.
 
 ## Product Decision
 
-The plan should intentionally ship in two layers:
+The plan should move in this order:
 
-1. A deterministic, PHPUnit-based memory-regression harness for the existing async worker-style path as the first blocking safety net.
-2. An HTTP-oriented memory evidence path for future FrankenPHP comparison, initially informational until the target runtime exists in the repository.
+1. rewrite the specs around FrankenPHP worker mode as the target runtime,
+2. audit mutable services and define reset responsibilities,
+3. add endpoint-wide same-kernel memory-safety tests using Symfony/PHPUnit,
+4. add high-risk service-level leak tests,
+5. verify the design in staging with conservative worker restarts,
+6. then enable worker mode in production with rollback guardrails.
+
+This is intentionally not a "flip the runtime and hope the tests hold" plan.
+
+## Assumptions / Open Questions
+
+- No committed FrankenPHP bootstrap exists yet.
+- The current documented HTTP surface is comprehensive enough to use as the
+  initial endpoint matrix.
+- The concrete authenticated endpoint still needs confirmation because the repo
+  does not obviously commit security firewall configuration.
+- The existence of a dedicated soak environment for long-running workers is not
+  yet obvious from the repository.
+- `shipmonk/memory-scanner` compatibility with the current PHPUnit/Symfony stack
+  still needs confirmation during implementation.
 
 ## Why Now
 
-Adding the regression coverage first de-risks the eventual worker-mode rollout and creates a stable baseline while the service is still on `php-fpm`. That makes the future runtime migration a controlled change with evidence, rather than a combined runtime-and-testing leap.
+Worker mode changes the application's failure modes. The cheapest time to define
+cleanup semantics, service reset rules, endpoint-wide repeated-request tests,
+and rollout guardrails is before the runtime switch is implemented. Doing this
+spec rewrite now turns the future migration into an evidence-driven change
+instead of a runtime gamble.

--- a/specs/autonomous/core-service-plan-memory-leak-worker-mode-1776003256/product-brief.md
+++ b/specs/autonomous/core-service-plan-memory-leak-worker-mode-1776003256/product-brief.md
@@ -59,12 +59,13 @@ assumptions are no longer sufficient.
 
 - Rewriting the existing BMAD planning bundle so FrankenPHP worker mode is the
   target architecture.
-- Defining the worker request lifecycle, cleanup requirements, and restart fuse.
-- Auditing mutable services and specifying `ResetInterface` requirements.
-- Defining an endpoint-wide memory-safety test layer for all current REST and
+- Specify the worker request lifecycle, cleanup requirements, and restart fuse.
+- Audit mutable services and define `ResetInterface` requirements.
+- Establish an endpoint-wide memory-safety test layer for all current REST and
   GraphQL operations.
-- Defining supporting `KernelTestCase` leak checks for high-risk service flows.
-- Defining CI, staging soak, rollout, and rollback policy for the migration.
+- Add supporting `KernelTestCase` leak checks for high-risk shared-service and
+  async flows.
+- Define CI, staging soak, rollout, and rollback policy for the migration.
 
 ## Out of Scope
 
@@ -75,13 +76,22 @@ assumptions are no longer sufficient.
 
 ## Success Metrics
 
-- The BMAD bundle makes FrankenPHP worker mode a first-class architectural
-  constraint instead of a future afterthought.
-- The plan defines how every documented endpoint will be exercised under
-  same-kernel repeated-request tests.
-- The plan defines a concrete reset strategy for mutable services.
-- The plan defines CI/staging signals that can detect retained state before
-  production rollout.
+- FrankenPHP worker mode remains blocked until the BMAD bundle defines it as a
+  first-class architectural constraint, not a future afterthought.
+- Worker mode remains blocked until every documented REST endpoint and GraphQL
+  operation is covered by same-kernel repeated-request tests, and those tests
+  pass using project-specific thresholds derived from baseline calibration
+  rather than invented values.
+- Worker mode remains blocked until supporting high-risk leak checks for shared
+  services and async-style execution paths, including
+  `DomainEventMessageHandler` happy and failure flows when present, are defined
+  as co-blocking signals and pass in CI.
+- Worker mode remains blocked until mutable services have a concrete reset
+  strategy, and the audit defines how that strategy is verified in CI and
+  staging.
+- Worker mode remains blocked until CI and staging expose green memory-regression
+  signals for retained objects, cross-request state bleed, and worker-restart
+  stability using baseline-derived thresholds established during calibration.
 - The plan gives engineers enough structure to implement the migration without
   inventing the memory-safety strategy from scratch.
 
@@ -115,7 +125,7 @@ The plan should move in this order:
 1. rewrite the specs around FrankenPHP worker mode as the target runtime,
 2. audit mutable services and define reset responsibilities,
 3. add endpoint-wide same-kernel memory-safety tests using Symfony/PHPUnit,
-4. add high-risk service-level leak tests,
+4. add co-blocking high-risk service-level and async/shared-service leak tests,
 5. verify the design in staging with conservative worker restarts,
 6. then enable worker mode in production with rollback guardrails.
 

--- a/specs/autonomous/core-service-plan-memory-leak-worker-mode-1776003256/research.md
+++ b/specs/autonomous/core-service-plan-memory-leak-worker-mode-1776003256/research.md
@@ -1,76 +1,183 @@
-# Research: Memory-Leak Regression Baseline for Worker-Mode Readiness
+# Research: FrankenPHP Worker-Mode Adoption and Memory-Safety Baseline
 
 ## Goal
 
-Define the research baseline for adding memory-leak regression tests before a future FrankenPHP worker-mode rollout. This document stays at research stage only. It does not define final implementation, CI policy, or hard thresholds.
+Define a repository-grounded baseline for moving core-service from `php-fpm` to
+FrankenPHP worker mode and for adding endpoint-wide memory-safety coverage that
+can detect retained state and memory leaks before rollout.
 
-## Current Evidence
+## Current Evidence From This Repository
 
-- The current runtime is `php-fpm` on PHP 8.4 Alpine with a separate Caddy image; the container entrypoint still ends with `CMD ["php-fpm"]`, so the service is not running FrankenPHP today.
-- The service uses DDD, CQRS, and event-driven patterns, so long-lived-process risk is not limited to HTTP request handling.
-- Two relevant harnesses already exist: PHPUnit in CI and K6 for REST load scenarios.
-- `DomainEventMessageHandler` and the `CustomerCreated*Subscriber` classes explicitly describe Symfony Messenger worker execution, making them the closest existing proxy for long-lived service reuse.
-- Current unit coverage for `DomainEventMessageHandler` validates behavior, continuation on failure, and logging/metrics paths, but it does not validate repeat-invocation memory stability.
+- The committed runtime is still `php-fpm` behind Caddy:
+  `Dockerfile` ends with `CMD ["php-fpm"]`, the container entrypoint defaults
+  to `php-fpm`, and `infrastructure/docker/caddy/Caddyfile` routes requests to
+  `php_fastcgi`.
+- No FrankenPHP bootstrap or worker loop is currently committed.
+- The repository uses Symfony 7.4, API Platform test tooling, and PHPUnit 10.5.
+- `tests/Integration/ObservabilityBusinessMetricsTest.php` already uses
+  `disableReboot()`, which proves the repo has a same-kernel BrowserKit test
+  primitive available today.
+- The service uses Doctrine MongoDB ODM, Redis-backed cache pools, Symfony
+  Messenger, serializer-heavy API Platform flows, and custom OpenAPI
+  normalizers. All of these are long-lived-state risk surfaces once the kernel
+  is reused across requests.
+- `src/Shared/Infrastructure/Bus/Event/Async/DomainEventMessageHandler.php`
+  already models worker-style processing and explicitly avoids logging payloads
+  because of PII concerns.
+- Repository scan did not find committed `ResetInterface` implementations or
+  app-level `kernel.reset` tags yet.
+- Repository scan did not find existing `shipmonk/memory-scanner`,
+  `arnaud-lb/memprof`, or `roave/no-leaks` dependencies.
+- The current public API surface is documented in `docs/api-endpoints.md` and
+  load-tested in `docs/performance.md`.
 
-## Why This Matters Before FrankenPHP
+## Why FrankenPHP Worker Mode Changes the Design
 
-FrankenPHP worker mode changes the memory model: application services and userland state can survive across requests. Current `php-fpm` request loops are only a partial proxy because they do not preserve the Symfony kernel/service lifecycle in the same way. Existing Messenger workers are a better near-term proxy because they already reuse process state across many messages.
+`php-fpm` resets process memory between requests. FrankenPHP worker mode does
+not. The Symfony kernel, service container, static state, caches, Doctrine ODM
+objects, serializer state, and request-derived references can survive from one
+request to the next.
 
-## Candidate Leak-Risk Surfaces
+That means the migration cannot be treated as a simple web-server swap. The
+application must be treated as a long-running process with explicit cleanup
+rules, worker restart safeguards, and tests that intentionally reuse the same
+kernel across multiple requests.
 
-1. Repeated async event handling in `DomainEventMessageHandler`, especially when the same handler and subscriber instances process many envelopes.
-2. Event subscribers that interact with shared services such as cache, logging, and metrics emission, including `CustomerCreatedCacheInvalidationSubscriber` and `CustomerCreatedMetricsSubscriber`.
-3. Repeated HTTP request handling under a future persistent worker runtime.
-4. Failure paths that allocate exceptions, logging context arrays, or metric objects on every iteration.
+Traditional request-isolated assumptions are therefore insufficient for this
+migration.
 
-## Baseline Research Position
+## Source Facts That Must Drive the Plan
 
-- PHPUnit should be the primary first-generation leak-regression harness because it can run deterministic loops in one PHP process and measure memory directly.
-- K6 should be the secondary harness for request-shaped workloads, but only when paired with external worker or container memory sampling; K6 alone is not a leak detector.
-- The first regression candidates should target async worker-style execution before HTTP worker-mode execution, because that path already exists today and is closer to long-lived application-state reuse than `php-fpm` request execution.
+1. Worker mode keeps the application booted and in memory across requests.
+2. The design must include explicit post-request cleanup and
+   `gc_collect_cycles()` in the worker loop.
+3. The rollout must include a MAX_REQUESTS-style restart fuse for legacy or
+   third-party leaks.
+4. Services that may retain mutable state between requests must implement
+   `ResetInterface` and clear state in `reset()`.
+5. Symfony functional tests can simulate same-process multi-request behavior
+   with `disableReboot()`.
+6. In `disableReboot()` mode Symfony resets `kernel.reset` services instead of
+   rebuilding the container, and this can affect security token storage and
+   Doctrine behavior.
+7. `shipmonk/memory-scanner` is the primary leak-testing package for this
+   migration.
+8. `KernelTestCase` and `WebTestCase` leak checks should use
+   `ObjectDeallocationCheckerKernelTestCaseTrait` where applicable.
+9. `arnaud-lb/memprof` is the optional deep-forensics tool for difficult cases.
+10. `roave/no-leaks` is not the primary solution for this migration.
 
-## Proposed Research Matrix
+## Endpoint Inventory That the Plan Must Cover
 
-| Scenario                                             | Harness               | Signal                                                       | Research value                                                  |
-| ---------------------------------------------------- | --------------------- | ------------------------------------------------------------ | --------------------------------------------------------------- |
-| Repeated happy-path async event handling             | PHPUnit               | heap delta, post-warmup slope, peak memory                   | Highest-fidelity current proxy for long-lived Symfony services  |
-| Repeated async failure path                          | PHPUnit               | growth under repeated exceptions and metric-failure handling | Validates resilience paths do not accumulate leaked state       |
-| Low-noise request loop such as `/api/health`         | K6 + external sampler | worker or container RSS trend                                | Establishes black-box HTTP baseline with minimal domain noise   |
-| Mixed request loop using existing customer scenarios | K6 + external sampler | RSS trend under serializer, cache, and logging churn         | Reuses current workload assets for future FrankenPHP comparison |
+### REST Endpoints
 
-## Measurement Principles
+Current documentation exposes nineteen REST routes:
 
-- Separate warm-up from measurement; first-use allocations, autoloading, and cache priming must not be treated as leaks.
-- Prefer steady-state criteria over a single absolute memory number.
-- Record memory in batches, not only at the end: initial, post-warmup, every N iterations, final, and peak.
-- For PHPUnit research, use in-process measures such as `memory_get_usage(true)` and `memory_get_peak_usage(true)` and force periodic GC during calibration to distinguish retained memory from collector lag.
-- For K6 research, measure PHP worker or container RSS externally; latency and throughput are supporting context, not pass or fail criteria.
+- `GET /api/health`
+- `GET /api/customers`
+- `POST /api/customers`
+- `GET /api/customers/{id}`
+- `PUT /api/customers/{id}`
+- `PATCH /api/customers/{id}`
+- `DELETE /api/customers/{id}`
+- `GET /api/customer_types`
+- `POST /api/customer_types`
+- `GET /api/customer_types/{id}`
+- `PUT /api/customer_types/{id}`
+- `PATCH /api/customer_types/{id}`
+- `DELETE /api/customer_types/{id}`
+- `GET /api/customer_statuses`
+- `POST /api/customer_statuses`
+- `GET /api/customer_statuses/{id}`
+- `PUT /api/customer_statuses/{id}`
+- `PATCH /api/customer_statuses/{id}`
+- `DELETE /api/customer_statuses/{id}`
 
-## Initial Research Hypotheses
+### GraphQL Operations
 
-1. The async domain-event path is the best first leak-regression target because it already runs in long-lived Symfony Messenger workers.
-2. Cache invalidation and metrics emission subscribers are representative starter cases because they exercise shared services rather than pure domain logic.
-3. Current `php-fpm` request-loop measurements can provide a useful baseline, but they are insufficient to prove readiness for FrankenPHP worker mode on their own.
-4. Leak thresholds should be calibrated empirically on stable runners before becoming blocking CI gates.
+Current documentation exposes fifteen GraphQL operations:
 
-## Known Gaps From Current Evidence
+- Queries:
+  `customer`, `customers`, `customerType`, `customerTypes`, `customerStatus`,
+  `customerStatuses`
+- Mutations:
+  `createCustomer`, `updateCustomer`, `deleteCustomer`,
+  `createCustomerType`, `updateCustomerType`, `deleteCustomerType`,
+  `createCustomerStatus`, `updateCustomerStatus`, `deleteCustomerStatus`
 
-- The architecture docs appear incomplete for current domain-event usage; code shows `CustomerCreatedEvent` subscribers while the design doc only lists a health-check event.
-- The K6 README documents workload execution, not worker-memory capture or leak-specific acceptance criteria.
-- Current GitHub workflows show PHPUnit and Symfony checks, but no leak-specific job or load-test job.
+The plan should treat this documented inventory as the baseline matrix for
+endpoint-wide memory-safety testing.
 
-## Recommended Output for the Next Phase
+## Highest-Risk Stateful Surfaces
 
-The next artifact set should decide:
+- Same-kernel HTTP request handling across the full REST and GraphQL surface
+- API Platform normalization and collection rendering
+- Doctrine ODM `DocumentManager` state across repeated reads and writes
+- Cache-backed repositories and tag invalidation logic
+- Long-lived SDK or infrastructure clients that may capture request-derived data
+- Observability emitters and log-context assembly
+- Messenger/domain-event subscriber chains using shared services
+- Static registries, memoizers, or arrays that can grow without bounds
 
-- which exact async scenarios become the first PHPUnit leak baselines,
-- how memory growth is sampled and normalized,
-- whether early K6 memory runs are informational or gating,
-- and what runner or environment contract is required before CI enforcement is credible.
+## Testing Implications for Symfony
 
-## Out of Scope
+- Endpoint-wide memory tests should use `WebTestCase`-compatible clients
+  (`ApiTestCase` in this repo) with `disableReboot()` so multiple requests reuse
+  the same kernel.
+- Service-level and message-level leak tests should use `KernelTestCase` with
+  `ObjectDeallocationCheckerKernelTestCaseTrait`.
+- `disableReboot()` is useful specifically because it approximates the same
+  application-kernel reuse that FrankenPHP worker mode introduces.
+- Because `disableReboot()` triggers resets instead of full container rebuilds,
+  leak tests must not assume that security token storage, Doctrine ODM unit of
+  work, or cached service state behave the same way they do in reboot-per-
+  request tests.
+- Test-environment adjustments will likely be required instead of naive
+  copy-paste from existing functional tests.
 
-- Implementing tests
-- Adopting FrankenPHP
-- Defining final thresholds
-- General performance benchmarking unrelated to memory retention
+## Tooling Position
+
+- Primary CI leak-testing package:
+  `shipmonk/memory-scanner`
+- Primary integration approach:
+  `KernelTestCase` and `WebTestCase` suites with
+  `ObjectDeallocationCheckerKernelTestCaseTrait`
+- Primary endpoint strategy:
+  repeated-request suites that cover the full documented REST and GraphQL
+  endpoint matrix
+- Secondary supporting suite:
+  high-risk service and async-worker flows such as `DomainEventMessageHandler`
+- Optional deep-debug path:
+  `arnaud-lb/memprof` in local or staging forensic runs
+- Explicit non-primary option:
+  do not anchor the migration on `roave/no-leaks`
+
+## Research Conclusion
+
+- The plan must treat FrankenPHP worker mode as the architectural destination,
+  not as a distant comparison target.
+- Endpoint-wide same-kernel repeated-request testing is the primary safety net,
+  because the migration risk is request-to-request retained state under a reused
+  Symfony kernel.
+- Async domain-event handling remains a valuable supporting suite because it
+  exercises long-lived shared-service behavior outside the HTTP entrypoint.
+- The rollout must be staged: spec rewrite, service audit, leak-focused test
+  implementation, staging soak, conservative worker rollout, then tuning from
+  measured evidence.
+
+## Assumptions / Open Questions
+
+- No FrankenPHP bootstrap was found in the repository. The exact worker
+  front-controller and loop structure still need confirmation during
+  implementation.
+- The repository uses PHPUnit 10.5 and Symfony 7.4 today, but
+  `shipmonk/memory-scanner` compatibility is still an implementation-time
+  check.
+- The repo scan did not find committed security firewall configuration, even
+  though OpenAPI factories model `401` responses. The authenticated endpoint
+  required by the test strategy still needs to be identified or introduced in a
+  test-safe way.
+- The repository documents K6 load testing but does not obviously document a
+  dedicated long-running-worker soak environment.
+- A service audit has not yet identified the hottest mutable services; that work
+  is part of the implementation backlog, not completed in this research phase.

--- a/specs/autonomous/core-service-plan-memory-leak-worker-mode-1776003256/research.md
+++ b/specs/autonomous/core-service-plan-memory-leak-worker-mode-1776003256/research.md
@@ -31,12 +31,12 @@ FrankenPHP worker mode changes the memory model: application services and userla
 
 ## Proposed Research Matrix
 
-| Scenario | Harness | Signal | Research value |
-| --- | --- | --- | --- |
-| Repeated happy-path async event handling | PHPUnit | heap delta, post-warmup slope, peak memory | Highest-fidelity current proxy for long-lived Symfony services |
-| Repeated async failure path | PHPUnit | growth under repeated exceptions and metric-failure handling | Validates resilience paths do not accumulate leaked state |
-| Low-noise request loop such as `/api/health` | K6 + external sampler | worker or container RSS trend | Establishes black-box HTTP baseline with minimal domain noise |
-| Mixed request loop using existing customer scenarios | K6 + external sampler | RSS trend under serializer, cache, and logging churn | Reuses current workload assets for future FrankenPHP comparison |
+| Scenario                                             | Harness               | Signal                                                       | Research value                                                  |
+| ---------------------------------------------------- | --------------------- | ------------------------------------------------------------ | --------------------------------------------------------------- |
+| Repeated happy-path async event handling             | PHPUnit               | heap delta, post-warmup slope, peak memory                   | Highest-fidelity current proxy for long-lived Symfony services  |
+| Repeated async failure path                          | PHPUnit               | growth under repeated exceptions and metric-failure handling | Validates resilience paths do not accumulate leaked state       |
+| Low-noise request loop such as `/api/health`         | K6 + external sampler | worker or container RSS trend                                | Establishes black-box HTTP baseline with minimal domain noise   |
+| Mixed request loop using existing customer scenarios | K6 + external sampler | RSS trend under serializer, cache, and logging churn         | Reuses current workload assets for future FrankenPHP comparison |
 
 ## Measurement Principles
 

--- a/specs/autonomous/core-service-plan-memory-leak-worker-mode-1776003256/research.md
+++ b/specs/autonomous/core-service-plan-memory-leak-worker-mode-1776003256/research.md
@@ -1,0 +1,76 @@
+# Research: Memory-Leak Regression Baseline for Worker-Mode Readiness
+
+## Goal
+
+Define the research baseline for adding memory-leak regression tests before a future FrankenPHP worker-mode rollout. This document stays at research stage only. It does not define final implementation, CI policy, or hard thresholds.
+
+## Current Evidence
+
+- The current runtime is `php-fpm` on PHP 8.4 Alpine with a separate Caddy image; the container entrypoint still ends with `CMD ["php-fpm"]`, so the service is not running FrankenPHP today.
+- The service uses DDD, CQRS, and event-driven patterns, so long-lived-process risk is not limited to HTTP request handling.
+- Two relevant harnesses already exist: PHPUnit in CI and K6 for REST load scenarios.
+- `DomainEventMessageHandler` and the `CustomerCreated*Subscriber` classes explicitly describe Symfony Messenger worker execution, making them the closest existing proxy for long-lived service reuse.
+- Current unit coverage for `DomainEventMessageHandler` validates behavior, continuation on failure, and logging/metrics paths, but it does not validate repeat-invocation memory stability.
+
+## Why This Matters Before FrankenPHP
+
+FrankenPHP worker mode changes the memory model: application services and userland state can survive across requests. Current `php-fpm` request loops are only a partial proxy because they do not preserve the Symfony kernel/service lifecycle in the same way. Existing Messenger workers are a better near-term proxy because they already reuse process state across many messages.
+
+## Candidate Leak-Risk Surfaces
+
+1. Repeated async event handling in `DomainEventMessageHandler`, especially when the same handler and subscriber instances process many envelopes.
+2. Event subscribers that interact with shared services such as cache, logging, and metrics emission, including `CustomerCreatedCacheInvalidationSubscriber` and `CustomerCreatedMetricsSubscriber`.
+3. Repeated HTTP request handling under a future persistent worker runtime.
+4. Failure paths that allocate exceptions, logging context arrays, or metric objects on every iteration.
+
+## Baseline Research Position
+
+- PHPUnit should be the primary first-generation leak-regression harness because it can run deterministic loops in one PHP process and measure memory directly.
+- K6 should be the secondary harness for request-shaped workloads, but only when paired with external worker or container memory sampling; K6 alone is not a leak detector.
+- The first regression candidates should target async worker-style execution before HTTP worker-mode execution, because that path already exists today and is closer to long-lived application-state reuse than `php-fpm` request execution.
+
+## Proposed Research Matrix
+
+| Scenario | Harness | Signal | Research value |
+| --- | --- | --- | --- |
+| Repeated happy-path async event handling | PHPUnit | heap delta, post-warmup slope, peak memory | Highest-fidelity current proxy for long-lived Symfony services |
+| Repeated async failure path | PHPUnit | growth under repeated exceptions and metric-failure handling | Validates resilience paths do not accumulate leaked state |
+| Low-noise request loop such as `/api/health` | K6 + external sampler | worker or container RSS trend | Establishes black-box HTTP baseline with minimal domain noise |
+| Mixed request loop using existing customer scenarios | K6 + external sampler | RSS trend under serializer, cache, and logging churn | Reuses current workload assets for future FrankenPHP comparison |
+
+## Measurement Principles
+
+- Separate warm-up from measurement; first-use allocations, autoloading, and cache priming must not be treated as leaks.
+- Prefer steady-state criteria over a single absolute memory number.
+- Record memory in batches, not only at the end: initial, post-warmup, every N iterations, final, and peak.
+- For PHPUnit research, use in-process measures such as `memory_get_usage(true)` and `memory_get_peak_usage(true)` and force periodic GC during calibration to distinguish retained memory from collector lag.
+- For K6 research, measure PHP worker or container RSS externally; latency and throughput are supporting context, not pass or fail criteria.
+
+## Initial Research Hypotheses
+
+1. The async domain-event path is the best first leak-regression target because it already runs in long-lived Symfony Messenger workers.
+2. Cache invalidation and metrics emission subscribers are representative starter cases because they exercise shared services rather than pure domain logic.
+3. Current `php-fpm` request-loop measurements can provide a useful baseline, but they are insufficient to prove readiness for FrankenPHP worker mode on their own.
+4. Leak thresholds should be calibrated empirically on stable runners before becoming blocking CI gates.
+
+## Known Gaps From Current Evidence
+
+- The architecture docs appear incomplete for current domain-event usage; code shows `CustomerCreatedEvent` subscribers while the design doc only lists a health-check event.
+- The K6 README documents workload execution, not worker-memory capture or leak-specific acceptance criteria.
+- Current GitHub workflows show PHPUnit and Symfony checks, but no leak-specific job or load-test job.
+
+## Recommended Output for the Next Phase
+
+The next artifact set should decide:
+
+- which exact async scenarios become the first PHPUnit leak baselines,
+- how memory growth is sampled and normalized,
+- whether early K6 memory runs are informational or gating,
+- and what runner or environment contract is required before CI enforcement is credible.
+
+## Out of Scope
+
+- Implementing tests
+- Adopting FrankenPHP
+- Defining final thresholds
+- General performance benchmarking unrelated to memory retention

--- a/specs/autonomous/core-service-plan-memory-leak-worker-mode-1776003256/run-summary.md
+++ b/specs/autonomous/core-service-plan-memory-leak-worker-mode-1776003256/run-summary.md
@@ -63,4 +63,4 @@
 
 ## Recommended Next Step
 
-Create the GitHub issue from this bundle, link the planning-only PR to that issue, and use Story `1.1` in [epics.md](./epics.md) as the first implementation entrypoint once the issue and PR are reviewed.
+Link or update the existing GitHub issue (`#166`) with this bundle, keep the planning-only PR attached to that issue, and use Story `1.1` in [epics.md](./epics.md) as the first implementation entrypoint once the issue and PR are reviewed.

--- a/specs/autonomous/core-service-plan-memory-leak-worker-mode-1776003256/run-summary.md
+++ b/specs/autonomous/core-service-plan-memory-leak-worker-mode-1776003256/run-summary.md
@@ -2,65 +2,71 @@
 
 ## Task Framing
 
-- Bundle directory: `specs/autonomous/core-service-plan-memory-leak-worker-mode-1776003256`
+- Bundle directory:
+  `specs/autonomous/core-service-plan-memory-leak-worker-mode-1776003256`
 - Issue: `#166`
-- Planning goal: add memory-leak regression tests before enabling FrankenPHP worker mode in core-service
-- Constraints: planning artifacts only, no production implementation, use BMAD stage subagents in the current Codex session
-- Planning artifact path override: repository BMAD config points to `_bmad-output/planning-artifacts`, but this run writes the tracked bundle under `specs/autonomous/` because the repository already stores autonomous planning bundles there and the user explicitly requested `specs/`
 - Working branch: `feat/memory-leak-worker-mode-planning`
-- Base branch: `origin/main`
+- Rewrite goal:
+  replace the earlier async-proxy-first planning angle with a worker-mode-first
+  BMAD bundle that plans the move from `php-fpm` to FrankenPHP and requires
+  memory-safety coverage for the full endpoint inventory
+- Scope of this update:
+  rewrite the existing BMAD artifacts in place; no production runtime or test
+  implementation yet
 
-## Context Snapshot
+## Repository Context Used for the Rewrite
 
-- `bmalph status` in the original workspace reported Phase 2 planning artifacts from an earlier local run, confirming CLI availability before the clean worktree was created.
-- The clean worktree initially lacked local `_bmad/` assets because they are gitignored; `bmalph upgrade --force` restored them locally for this planning run, and the resulting tracked wrapper changes were restored before continuing.
-- Current application runtime is `php-fpm` plus Caddy according to `Dockerfile`; FrankenPHP is not yet wired into this repository, so the planning target is preventive coverage for a future worker-mode migration.
-- Existing test surfaces include PHPUnit unit/integration suites, Behat E2E tests, Bats coverage for Make targets, and K6 load tests under `tests/Load/`.
+- The committed runtime is still `php-fpm` plus Caddy.
+- PHPUnit 10.5 and Symfony 7.4 are in use.
+- `tests/Integration/ObservabilityBusinessMetricsTest.php` already uses
+  `disableReboot()`, which provides a real same-kernel testing primitive.
+- `DomainEventMessageHandler` models long-lived shared-service execution and
+  already enforces PII-safe logging posture.
+- The documented API surface currently includes nineteen REST endpoints and
+  fifteen GraphQL operations.
+- No committed FrankenPHP bootstrap, app-level `ResetInterface`, or
+  `shipmonk/memory-scanner` integration exists yet.
 
-## Subagent Execution Log
+## Major Planning Decisions Rewritten
 
-- Research
-  BMALPH command: `analyst`
-  Artifact: `research.md`
-  Result: complete draft returned by a dedicated subagent and adopted with the async domain-event worker path selected as the primary pre-FrankenPHP leak-regression proxy.
-- Product Brief
-  BMALPH command: `create-brief`
-  Artifact: `product-brief.md`
-  Result: the dedicated brief-stage subagent returned a compatible draft after the tracked brief was normalized in the main session; the adopted result keeps the scope strictly on the prerequisite testing initiative, not the FrankenPHP migration itself, and no separate distillate is required.
-- PRD
-  BMALPH command: `create-prd`
-  Artifact: `prd.md`
-  Result: draft finalized in the main session with measurable functional and non-functional requirements centered on deterministic async-worker memory regression first and informational HTTP evidence second.
-- Architecture
-  BMALPH command: `create-architecture`
-  Artifact: `architecture.md`
-  Result: draft finalized in the main session with a two-layer testing architecture: blocking PHPUnit-based async worker regression and later non-blocking HTTP memory evidence.
-- Epics and Stories
-  BMALPH command: `create-epics-stories`
-  Artifact: `epics.md`
-  Result: draft finalized in the main session with three epics covering measurement foundation, scenario coverage, and operational rollout guardrails.
-- Implementation Readiness
-  BMALPH command: `implementation-readiness`
-  Artifact: `implementation-readiness.md`
-  Result: draft finalized in the main session with a readiness verdict of ready-to-plan, contingent on approving the phased signal strategy and threshold-calibration policy.
+- FrankenPHP worker mode is now the architectural destination, not a later
+  comparison target.
+- The plan now requires endpoint-wide same-kernel memory-safety testing across
+  the full documented REST and GraphQL inventory.
+- The plan requires explicit worker-loop cleanup with `gc_collect_cycles()`.
+- The plan requires a MAX_REQUESTS-style fuse for staging and early production.
+- The plan requires a service audit and `ResetInterface` strategy for mutable
+  long-lived services.
+- `shipmonk/memory-scanner` is now positioned as the primary leak-testing
+  package.
+- `KernelTestCase` and `WebTestCase` with
+  `ObjectDeallocationCheckerKernelTestCaseTrait` are now the primary Symfony
+  integration path.
+- `arnaud-lb/memprof` is documented as the deep-forensics escalation path.
+- `roave/no-leaks` is explicitly not the primary migration solution.
 
-## Validation Rounds
+## Open Questions, Warnings, and Blockers
 
-- Research: 1 round
-- Product Brief: 1 round
-- PRD: 1 round
-- Architecture: 1 round
-- Epics and Stories: 1 round
-- Implementation Readiness: 1 round
-
-## Open Questions, Warnings, And Blockers
-
-- Open question: whether the eventual worker-mode rollout will replace `php-fpm` fully with FrankenPHP or keep a dual runtime path for some period.
-- Open question: whether the preferred regression signal is RSS growth across repeated requests, PHP heap growth, object-count drift, or a composite threshold.
-- Warning: current repository CI does not exercise FrankenPHP because the runtime is still `php-fpm`; the plan must therefore specify a deterministic pre-migration test harness rather than assume existing workflows cover worker mode.
-- Warning: CodeRabbit approval is required by repository guidance, but local automation for forcing that approval has not been identified yet and may depend on the GitHub App reviewing the opened PR asynchronously.
-- Warning: the product-brief stage subagent was launched, but the bundle was advanced in the main session to keep the autonomous run moving; if the delayed subagent output arrives before PR creation completes, it should be compared against the tracked draft for any high-signal gaps only.
+- Open question:
+  what exact FrankenPHP worker bootstrap and front-controller shape will replace
+  the current `php-fpm` setup?
+- Open question:
+  which concrete authenticated endpoint should anchor the mandatory protected-
+  route repeated-request scenario, given the lack of obvious committed firewall
+  configuration?
+- Open question:
+  does the team already have a staging or soak environment suitable for
+  long-running worker verification?
+- Warning:
+  numeric memory thresholds are intentionally not set yet; baseline measurement
+  must be established first.
+- Warning:
+  the migration must not rely on MAX_REQUESTS alone; restart fuses are a safety
+  net, not a substitute for leak fixes.
 
 ## Recommended Next Step
 
-Link or update the existing GitHub issue (`#166`) with this bundle, keep the planning-only PR attached to that issue, and use Story `1.1` in [epics.md](./epics.md) as the first implementation entrypoint once the issue and PR are reviewed.
+Use **Epic 1, Story 1.1** from [epics.md](./epics.md) as the first execution
+entry point: audit the container for mutable long-lived state, classify risky
+services, and use that inventory to drive the `ResetInterface` and leak-test
+implementation work.

--- a/specs/autonomous/core-service-plan-memory-leak-worker-mode-1776003256/run-summary.md
+++ b/specs/autonomous/core-service-plan-memory-leak-worker-mode-1776003256/run-summary.md
@@ -1,0 +1,66 @@
+# Run Summary
+
+## Task Framing
+
+- Bundle directory: `specs/autonomous/core-service-plan-memory-leak-worker-mode-1776003256`
+- Issue: `#166`
+- Planning goal: add memory-leak regression tests before enabling FrankenPHP worker mode in core-service
+- Constraints: planning artifacts only, no production implementation, use BMAD stage subagents in the current Codex session
+- Planning artifact path override: repository BMAD config points to `_bmad-output/planning-artifacts`, but this run writes the tracked bundle under `specs/autonomous/` because the repository already stores autonomous planning bundles there and the user explicitly requested `specs/`
+- Working branch: `feat/memory-leak-worker-mode-planning`
+- Base branch: `origin/main`
+
+## Context Snapshot
+
+- `bmalph status` in the original workspace reported Phase 2 planning artifacts from an earlier local run, confirming CLI availability before the clean worktree was created.
+- The clean worktree initially lacked local `_bmad/` assets because they are gitignored; `bmalph upgrade --force` restored them locally for this planning run, and the resulting tracked wrapper changes were restored before continuing.
+- Current application runtime is `php-fpm` plus Caddy according to `Dockerfile`; FrankenPHP is not yet wired into this repository, so the planning target is preventive coverage for a future worker-mode migration.
+- Existing test surfaces include PHPUnit unit/integration suites, Behat E2E tests, Bats coverage for Make targets, and K6 load tests under `tests/Load/`.
+
+## Subagent Execution Log
+
+- Research
+  BMALPH command: `analyst`
+  Artifact: `research.md`
+  Result: complete draft returned by a dedicated subagent and adopted with the async domain-event worker path selected as the primary pre-FrankenPHP leak-regression proxy.
+- Product Brief
+  BMALPH command: `create-brief`
+  Artifact: `product-brief.md`
+  Result: the dedicated brief-stage subagent returned a compatible draft after the tracked brief was normalized in the main session; the adopted result keeps the scope strictly on the prerequisite testing initiative, not the FrankenPHP migration itself, and no separate distillate is required.
+- PRD
+  BMALPH command: `create-prd`
+  Artifact: `prd.md`
+  Result: draft finalized in the main session with measurable functional and non-functional requirements centered on deterministic async-worker memory regression first and informational HTTP evidence second.
+- Architecture
+  BMALPH command: `create-architecture`
+  Artifact: `architecture.md`
+  Result: draft finalized in the main session with a two-layer testing architecture: blocking PHPUnit-based async worker regression and later non-blocking HTTP memory evidence.
+- Epics and Stories
+  BMALPH command: `create-epics-stories`
+  Artifact: `epics.md`
+  Result: draft finalized in the main session with three epics covering measurement foundation, scenario coverage, and operational rollout guardrails.
+- Implementation Readiness
+  BMALPH command: `implementation-readiness`
+  Artifact: `implementation-readiness.md`
+  Result: draft finalized in the main session with a readiness verdict of ready-to-plan, contingent on approving the phased signal strategy and threshold-calibration policy.
+
+## Validation Rounds
+
+- Research: 1 round
+- Product Brief: 1 round
+- PRD: 1 round
+- Architecture: 1 round
+- Epics and Stories: 1 round
+- Implementation Readiness: 1 round
+
+## Open Questions, Warnings, And Blockers
+
+- Open question: whether the eventual worker-mode rollout will replace `php-fpm` fully with FrankenPHP or keep a dual runtime path for some period.
+- Open question: whether the preferred regression signal is RSS growth across repeated requests, PHP heap growth, object-count drift, or a composite threshold.
+- Warning: current repository CI does not exercise FrankenPHP because the runtime is still `php-fpm`; the plan must therefore specify a deterministic pre-migration test harness rather than assume existing workflows cover worker mode.
+- Warning: CodeRabbit approval is required by repository guidance, but local automation for forcing that approval has not been identified yet and may depend on the GitHub App reviewing the opened PR asynchronously.
+- Warning: the product-brief stage subagent was launched, but the bundle was advanced in the main session to keep the autonomous run moving; if the delayed subagent output arrives before PR creation completes, it should be compared against the tracked draft for any high-signal gaps only.
+
+## Recommended Next Step
+
+Create the GitHub issue from this bundle, link the planning-only PR to that issue, and use Story `1.1` in [epics.md](./epics.md) as the first implementation entrypoint once the issue and PR are reviewed.

--- a/tests/Load/Dockerfile
+++ b/tests/Load/Dockerfile
@@ -1,12 +1,23 @@
+ARG XK6_VERSION=v1.3.7
+ARG K6_VERSION=v1.7.1
+ARG XK6_FILE_VERSION=v1.6.1
+ARG XK6_COUNTER_VERSION=v0.0.1
+
 FROM golang:1.25-alpine AS builder
+
+ARG XK6_VERSION
+ARG K6_VERSION
+ARG XK6_FILE_VERSION
+ARG XK6_COUNTER_VERSION
 
 RUN apk add --no-cache git
 
-RUN go install go.k6.io/xk6/cmd/xk6@latest && \
-    xk6 build --with github.com/avitalique/xk6-file@latest \
-              --with github.com/mstoykov/xk6-counter@latest
+RUN go install go.k6.io/xk6/cmd/xk6@${XK6_VERSION} && \
+    xk6 build --k6-version ${K6_VERSION} \
+              --with github.com/avitalique/xk6-file@${XK6_FILE_VERSION} \
+              --with github.com/mstoykov/xk6-counter@${XK6_COUNTER_VERSION}
 
-FROM grafana/k6:latest
+FROM grafana/k6:1.7.1
 
 COPY --from=builder /go/k6 /usr/bin/k6
 


### PR DESCRIPTION
## Description

Adds a BMAD/BMALPH planning-only bundle under `specs/autonomous/core-service-plan-memory-leak-worker-mode-1776003256/` for the prerequisite work to add memory-leak regression coverage before FrankenPHP worker mode is enabled.

The bundle includes:
- research
- product brief
- PRD
- architecture
- epics and stories
- implementation readiness
- run summary

## Related Issue

Closes #166

## Motivation and Context

We want FrankenPHP worker mode later, but the repository currently has no dedicated memory-retention regression strategy for long-lived execution paths. This PR adds the planning artifacts first so the implementation can start from an agreed scope, risk model, and rollout gate instead of combining runtime migration and memory-safety design in one step.

## How Has This Been Tested?

- `git diff --check`
- local bundle consistency review
- local `make ci` is running in an isolated high-port environment for this branch
- GitHub Actions checks are expected on this PR

## Screenshots (if appropriate):

N/A

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project.
- [x] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING.md**](https://github.com/VilnaCRM-Org/core-service/blob/main/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] You have only one commit (if not, squash them into one commit).
- [ ] Structurizr documentation has been updated to reflect any architectural changes.
