### PR TITLE
docs: add issue 176 abstract cache refresh planning

### DIFF
--- a/.claude/skills/cache-management/SKILL.md
+++ b/.claude/skills/cache-management/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: cache-management
-description: Implement production-grade caching with cache keys/TTLs/consistency classes per query, SWR (stale-while-revalidate), explicit invalidation, and comprehensive testing for stale reads and cache warmup. Use when adding caching to queries, implementing cache invalidation, or ensuring cache consistency and performance.
+description: Implement production-grade caching with cache keys/TTLs/consistency classes per query, SWR (stale-while-revalidate), layered explicit invalidation, and comprehensive testing for stale reads and cache warmup. Use when adding caching to queries, implementing cache invalidation, or ensuring cache consistency and performance.
 ---
 
 # Cache Management Skill
@@ -10,7 +10,7 @@ description: Implement production-grade caching with cache keys/TTLs/consistency
 Use this skill when:
 
 - Adding caching to repositories or expensive queries
-- Implementing cache invalidation via domain events
+- Implementing cache invalidation via domain events, Doctrine ODM lifecycle events, or repository fallback hooks
 - Defining cache keys, TTLs, and consistency requirements
 - Implementing stale-while-revalidate (SWR) pattern
 - Testing cache behavior (stale reads, cold start, invalidation)
@@ -18,13 +18,13 @@ Use this skill when:
 
 ## Task (Function)
 
-Implement production-ready caching with proper key design, TTL management, event-driven invalidation, and comprehensive testing.
+Implement production-ready caching with proper key design, TTL management, layered explicit invalidation, and comprehensive testing.
 
 **Success Criteria**:
 
 - Cache policy declared for each query (key, TTL, consistency class)
 - Decorator pattern with `CachedXxxRepository` wrapping `MongoXxxRepository`
-- Event-driven invalidation via domain event subscribers
+- Layered invalidation via domain event subscribers, ODM lifecycle listeners, and repository fallback hooks for custom writes that bypass ODM observation
 - Best-effort invalidation (try/catch, never fail business operations)
 - Comprehensive unit tests for all cache paths
 - Cache observability (hit/miss/error logging)
@@ -38,12 +38,12 @@ Implement production-ready caching with proper key design, TTL management, event
 ╔═══════════════════════════════════════════════════════════════╗
 ║  ALWAYS use Decorator Pattern for caching (wrap repositories) ║
 ║  ALWAYS use CacheKeyBuilder service (prevent key drift)       ║
-║  ALWAYS invalidate via Domain Events (decouple from business) ║
+║  ALWAYS invalidate via explicit mapped write signals           ║
 ║  ALWAYS use TagAwareCacheInterface for cache tags             ║
 ║  ALWAYS wrap cache ops in try/catch (best-effort, no failures)║
 ║                                                               ║
-║  ❌ FORBIDDEN: Caching in repository, implicit invalidation   ║
-║  ✅ REQUIRED:  Decorator pattern, event-driven invalidation   ║
+║  ❌ FORBIDDEN: Caching in repository, unmapped invalidation    ║
+║  ✅ REQUIRED:  Decorators + layered explicit invalidation      ║
 ╚═══════════════════════════════════════════════════════════════╝
 ```
 
@@ -51,7 +51,10 @@ Implement production-ready caching with proper key design, TTL management, event
 
 - Use Decorator Pattern: `CachedXxxRepository` wraps `MongoXxxRepository`
 - Use centralized `CacheKeyBuilder` service (in `Shared/Infrastructure/Cache`)
-- Invalidate via Domain Event Subscribers (one subscriber per event)
+- Invalidate through every reliable write signal:
+  - Domain event subscribers when events are exposed
+  - Doctrine ODM lifecycle listeners for managed document changes
+  - Repository fallback hooks for custom bulk/direct writes that bypass ODM change sets
 - Wrap ALL cache operations in try/catch (never fail business operations)
 - Use `TagAwareCacheInterface` (not `CacheInterface`) for tag support
 - Configure test cache pools with `tags: true` in `config/packages/test/cache.yaml`
@@ -81,13 +84,15 @@ Implement production-ready caching with proper key design, TTL management, event
 - [ ] Identified slow query worth caching (use query-performance-analysis)
 - [ ] Cache policy declared (key pattern, TTL, consistency class)
 - [ ] Cache tags defined for invalidation strategy
-- [ ] Domain events defined for cache invalidation triggers
+- [ ] Reliable invalidation triggers defined: domain events, ODM change sets, and repository fallback hooks where needed
 
 **Architecture Setup:**
 
 - [ ] Created `CachedXxxRepository` decorator class
 - [ ] Created `CacheKeyBuilder` service (or extended existing one)
-- [ ] Created cache invalidation event subscribers (one per event)
+- [ ] Created cache invalidation event subscribers for exposed domain events
+- [ ] Created ODM invalidation listener/rules for managed document create/update/delete
+- [ ] Classified custom repository writes as ODM-observed or repository-fallback required
 - [ ] Configured services.yaml with explicit cache pool injection
 
 **During Implementation:**
@@ -95,7 +100,7 @@ Implement production-ready caching with proper key design, TTL management, event
 - [ ] Decorator wraps inner repository (not extends)
 - [ ] CacheKeyBuilder used for all cache keys (prevents drift)
 - [ ] Cache operations wrapped in try/catch (best-effort)
-- [ ] Event subscribers use same CacheKeyBuilder for tags
+- [ ] Event subscribers, ODM listeners, and repository fallbacks use the same tag/rule resolvers
 - [ ] Logging added for cache hits/misses/errors
 - [ ] Repository uses `TagAwareCacheInterface` (required for tags)
 
@@ -103,6 +108,8 @@ Implement production-ready caching with proper key design, TTL management, event
 
 - [ ] Test cache pool configured with `tags: true`
 - [ ] Unit tests for cache invalidation subscribers
+- [ ] Unit tests for ODM listener invalidation
+- [ ] Unit tests for repository fallback invalidation where custom writes bypass ODM observation
 - [ ] Integration tests for stale reads after writes
 - [ ] Test: Cache error fallback to database works
 
@@ -197,8 +204,9 @@ final readonly class CacheKeyBuilder
  * - Delegates ALL persistence operations to inner repository
  *
  * Cache Invalidation:
- * - Handled by *CacheInvalidationSubscriber classes via domain events
- * - This class only reads from cache, never invalidates (except delete)
+ * - Handled by explicit invalidation sources:
+ *   domain-event subscribers, ODM lifecycle listeners, or repository fallbacks
+ * - This class only reads from cache and delegates writes
  */
 final class CachedCustomerRepository implements CustomerRepositoryInterface
 {
@@ -253,7 +261,8 @@ final class CachedCustomerRepository implements CustomerRepositoryInterface
     public function save(Customer $customer): void
     {
         $this->inner->save($customer);
-        // NO cache invalidation here - handled by domain event subscribers
+        // No read-through cache logic here.
+        // Invalidation is handled by mapped write signals.
     }
 
     public function delete(Customer $customer): void
@@ -560,9 +569,11 @@ make ci
 - **Write-through**: Invalidate immediately after writes
 - **Tag-based**: Batch invalidation using cache tags
 - **Event-driven**: Invalidate via domain events
+- **ODM lifecycle**: Invalidate when managed documents change
+- **Repository fallback**: Invalidate after custom bulk/direct writes that bypass ODM change sets
 - **Time-based**: TTL-only (for static data)
 
-**Critical Rule**: ALWAYS invalidate explicitly on create/update/delete
+**Critical Rule**: ALWAYS invalidate explicitly on create/update/delete through every reliable write signal.
 
 ```php
 // ✅ CORRECT
@@ -625,18 +636,20 @@ public function findById(string $id): ?Customer
 
 - **NO caching** - Pure business logic
 - Domain entities are cache-agnostic
-- Domain events carry data needed for cache invalidation
+- Domain events should carry data needed for cache invalidation when they are exposed
 
 ### Application Layer
 
 - **Command Handlers** publish domain events (not invalidate directly)
-- **Event Subscribers** handle cache invalidation via domain events
+- **Event Subscribers** handle cache invalidation via exposed domain events
 
 ### Infrastructure Layer
 
 - **CachedXxxRepository** decorates MongoXxxRepository (read-through caching)
 - **MongoXxxRepository** handles persistence only
-- Cache invalidation triggered by domain events, NOT in save()
+- **Doctrine ODM listeners** handle managed document create/update/delete invalidation
+- **Repository fallback hooks** handle custom writes that bypass ODM change sets
+- Domain repository interfaces stay cache-free
 
 **Architecture Flow**:
 
@@ -651,22 +664,24 @@ public function findById(string $id): ?Customer
 ┌─────────────────────────────────────────────────────────────┐
 │  CachedCustomerRepository (Decorator)                       │
 │  └─ inner.save(customer)  // delegates to Mongo             │
-│  └─ (NO invalidation here!)                                 │
+│  └─ no read-through cache mutation in write path            │
 └─────────────────────────────────────────────────────────────┘
                             │
                             ▼
 ┌─────────────────────────────────────────────────────────────┐
-│  CustomerUpdatedCacheInvalidationSubscriber                 │
-│  └─ cache.invalidateTags([...])  // event-driven!           │
+│  Layered invalidation                                      │
+│  ├─ Domain event subscriber when event is exposed           │
+│  ├─ ODM listener when managed document changes              │
+│  └─ Repository fallback for unobservable custom writes      │
 └─────────────────────────────────────────────────────────────┘
 ```
 
-**Why Event-Driven Invalidation?**
+**Why Layered Explicit Invalidation?**
 
-1. **Decoupling**: Repository doesn't know about cache invalidation strategy
-2. **Testability**: Easier to test invalidation logic separately
-3. **Flexibility**: Can add more invalidation logic without touching repository
-4. **Consistency**: Same event triggers multiple side effects (cache, notifications, etc.)
+1. **Coverage**: Domain events cover business signals, ODM covers entity changes, and repository fallbacks cover custom write paths.
+2. **Decoupling**: Domain repository interfaces stay cache-free.
+3. **Testability**: Invalidation rules and resolvers are tested separately.
+4. **Consistency**: All sources use the same cache tags and idempotent invalidation command.
 
 ---
 
@@ -700,12 +715,13 @@ $this->logger->info('Cache miss - loading from database', [
 - Don't cache without declaring policy first
 - Don't cache without TTL
 - Don't cache in Domain layer
-- Don't use implicit invalidation (use events!)
+- Don't use unmapped invalidation or rely on TTL alone
 - Don't share cache keys between different queries
 - Don't cache sensitive data (PII, passwords, tokens)
 - Don't cache without testing all paths
 - Don't forget to log cache operations
-- Don't invalidate in repository save() method (use event subscribers!)
+- Don't put cache invalidation in Domain repository interfaces
+- Don't add repository fallback hooks unless the write bypasses ODM change-set observation
 - Don't forget to handle email changes (invalidate both old and new email caches)
 
 ### ✅ DO

--- a/.claude/skills/cache-management/reference/invalidation-strategies.md
+++ b/.claude/skills/cache-management/reference/invalidation-strategies.md
@@ -1,6 +1,6 @@
 # Cache Invalidation Strategies
 
-Complete guide for implementing explicit cache invalidation: write-through, event-driven, tag-based, and time-based strategies.
+Complete guide for implementing explicit cache invalidation: write-through, event-driven, ODM lifecycle, repository fallback, tag-based, and time-based strategies.
 
 ## Core Principle: Explicit Over Implicit
 
@@ -30,14 +30,24 @@ public function save(Customer $customer): void
 
 ## Invalidation Strategy Matrix
 
-| Strategy          | When to Use                       | Complexity | Consistency    |
-| ----------------- | --------------------------------- | ---------- | -------------- |
-| **Write-through** | Single entity CRUD operations     | Low        | Strong         |
-| **Tag-based**     | Batch invalidation, related data  | Low        | Strong         |
-| **Event-driven**  | Complex domain events, decoupling | Medium     | Strong         |
-| **Time-based**    | Static data, aggregations         | Low        | Eventual       |
-| **Manual**        | One-off operations, bulk imports  | Low        | User-triggered |
-| **Lazy (TTL)**    | Acceptable staleness, low churn   | Very Low   | Eventual       |
+| Strategy                | When to Use                                      | Complexity | Consistency    |
+| ----------------------- | ------------------------------------------------ | ---------- | -------------- |
+| **ODM lifecycle**       | Managed document create/update/delete operations | Medium     | Strong         |
+| **Event-driven**        | Exposed domain events and cross-context effects  | Medium     | Strong         |
+| **Repository fallback** | Custom bulk/direct writes that bypass ODM        | Medium     | Strong         |
+| **Write-through**       | Small isolated operations                        | Low        | Strong         |
+| **Tag-based**           | Batch invalidation, related data                 | Low        | Strong         |
+| **Time-based**          | Static data, aggregations                        | Low        | Eventual       |
+| **Manual**              | One-off operations, bulk imports                 | Low        | User-triggered |
+| **Lazy (TTL)**          | Acceptable staleness, low churn                  | Very Low   | Eventual       |
+
+For this repository, prefer a layered model:
+
+1. Domain event subscribers invalidate when domain events are exposed.
+2. Doctrine ODM listeners invalidate when managed documents change.
+3. Repository fallback hooks invalidate after custom writes that bypass ODM change-set observation.
+
+All three sources should use the same tag/rule resolver surface and idempotent invalidation command.
 
 ---
 
@@ -658,16 +668,17 @@ public function testRelatedCachesInvalidated(): void
 
 ## Recommended Strategy by Use Case
 
-| Use Case                   | Recommended Strategy         | Rationale                    |
-| -------------------------- | ---------------------------- | ---------------------------- |
-| Single entity CRUD         | Write-through                | Simple, predictable          |
-| Entity with related data   | Tag-based                    | Invalidate multiple caches   |
-| Complex domain events      | Event-driven                 | Decouple logic, flexibility  |
-| External data imports      | Manual + Time-based          | Control when refresh happens |
-| Historical/archival data   | Time-based only              | Data never changes           |
-| High-frequency writes      | SWR (see swr-pattern.md)     | Reduce invalidation overhead |
-| Multi-tenant isolation     | Tag-based (with tenant tags) | Isolate cache by tenant      |
-| Cross-service invalidation | Event-driven (message bus)   | Distributed invalidation     |
+| Use Case                   | Recommended Strategy         | Rationale                                    |
+| -------------------------- | ---------------------------- | -------------------------------------------- |
+| Single entity CRUD         | ODM lifecycle                | Covers managed document writes automatically |
+| Entity with related data   | Tag-based                    | Invalidate multiple caches                   |
+| Complex domain events      | Event-driven                 | Decouple logic, flexibility                  |
+| Custom bulk/direct writes  | Repository fallback          | Covers writes ODM cannot observe             |
+| External data imports      | Manual + Time-based          | Control when refresh happens                 |
+| Historical/archival data   | Time-based only              | Data never changes                           |
+| High-frequency writes      | SWR (see swr-pattern.md)     | Reduce invalidation overhead                 |
+| Multi-tenant isolation     | Tag-based (with tenant tags) | Isolate cache by tenant                      |
+| Cross-service invalidation | Event-driven (message bus)   | Distributed invalidation                     |
 
 ---
 
@@ -678,13 +689,17 @@ public function testRelatedCachesInvalidated(): void
 1. **Always invalidate explicitly** on write operations
 2. **Use cache tags** for flexible batch invalidation
 3. **Consider related caches** when invalidating
-4. **Test invalidation behavior** thoroughly
-5. **Log invalidation events** for debugging
-6. **Document invalidation strategy** in cache policy
+4. **Layer invalidation sources**: domain events, ODM lifecycle, and repository fallback where needed
+5. **Test invalidation behavior** thoroughly
+6. **Log invalidation events** for debugging
+7. **Document invalidation strategy** in cache policy
 
 **Invalidation Checklist**:
 
 - ✅ Invalidate on create/update/delete
+- ✅ Invalidate on exposed domain events
+- ✅ Invalidate on managed ODM document changes
+- ✅ Add repository fallback hooks for custom writes that bypass ODM change sets
 - ✅ Use cache tags for batch operations
 - ✅ Invalidate related caches (lists, aggregations)
 - ✅ Log invalidation events

--- a/.claude/skills/code-organization/SKILL.md
+++ b/.claude/skills/code-organization/SKILL.md
@@ -42,12 +42,17 @@ Before proposing a source tree, creating files, or responding to review feedback
 4. Name the class after its responsibility and place it in the matching directory.
 5. Avoid broad directories such as `Cache/`, `Policy/`, `Registry/`, `Scheduler/`, `Manager/`, `Helper/`, or `Service/` when an existing precise type directory fits.
 
-For CQRS in this repository, async work can still be a command:
+For CQRS in this repository, async work can still be a command. If the work must be reusable across bounded contexts, define the generic command and worker in `Shared`, then add bounded-context adapters:
 
-- `Application/Command/RefreshCustomerCacheCommand.php`
-- `Application/CommandHandler/RefreshCustomerCacheCommandHandler.php`
+- `Shared/Application/Command/RefreshCacheCommand.php`
+- `Shared/Application/CommandHandler/RefreshCacheCommandHandler.php`
+- `Shared/Application/CommandHandler/AbstractCacheRefreshCommandHandler.php`
+- `Core/Customer/Application/CommandHandler/CustomerCacheRefreshCommandHandler.php`
+- `Core/Customer/Application/Factory/CustomerCacheRefreshCommandFactory.php`
 
 Do not invent `Message` or `MessageHandler` for async work if the same intent fits the existing Command/CommandHandler pattern. Do not invent `ReadModel`, `Query`, or `QueryHandler` unless the current context already uses that pattern and deptrac collects it.
+
+Shared metrics belong under the existing observability structure, for example `Shared/Application/Observability/Metric/CacheRefreshSucceededMetric.php`, not a new bounded-context metric bucket when the metric represents cross-context lifecycle behavior.
 
 ## Quick Reference: Where Does It Belong?
 

--- a/.claude/skills/code-organization/SKILL.md
+++ b/.claude/skills/code-organization/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: code-organization
-description: Ensure proper code organization with class names, directories, namespaces, and naming consistency following the principle "Directory X contains ONLY class type X (project)
+description: Ensure proper code organization with class names, directories, namespaces, and naming consistency following the principle "Directory X contains ONLY class type X".
 ---
 
 # Code Organization Skill
@@ -31,6 +31,23 @@ Examples:
 - `Cleaner/` → Contains ONLY cleaners
 - `Factory/` → Contains ONLY factories
 - `Resolver/` → Contains ONLY resolvers
+
+## Repository-First Directory Architecture
+
+Before proposing a source tree, creating files, or responding to review feedback about architecture:
+
+1. Inspect the current context directories, for example `find src/Core/Customer -maxdepth 4 -type d | sort`.
+2. Inspect `deptrac.yaml` collectors for directory names that are already recognized.
+3. Prefer existing class-type directories over new feature buckets.
+4. Name the class after its responsibility and place it in the matching directory.
+5. Avoid broad directories such as `Cache/`, `Policy/`, `Registry/`, `Scheduler/`, `Manager/`, `Helper/`, or `Service/` when an existing precise type directory fits.
+
+For CQRS in this repository, async work can still be a command:
+
+- `Application/Command/RefreshCustomerCacheCommand.php`
+- `Application/CommandHandler/RefreshCustomerCacheCommandHandler.php`
+
+Do not invent `Message` or `MessageHandler` for async work if the same intent fits the existing Command/CommandHandler pattern. Do not invent `ReadModel`, `Query`, or `QueryHandler` unless the current context already uses that pattern and deptrac collects it.
 
 ## Quick Reference: Where Does It Belong?
 

--- a/.claude/skills/code-organization/SKILL.md
+++ b/.claude/skills/code-organization/SKILL.md
@@ -44,8 +44,8 @@ Before proposing a source tree, creating files, or responding to review feedback
 
 For CQRS in this repository, async work can still be a command. If the work must be reusable across bounded contexts, define the generic command and worker in `Shared`, then add bounded-context adapters:
 
-- `Shared/Application/Command/RefreshCacheCommand.php`
-- `Shared/Application/CommandHandler/RefreshCacheCommandHandler.php`
+- `Shared/Application/Command/CacheRefreshCommand.php`
+- `Shared/Application/CommandHandler/CacheRefreshCommandHandler.php`
 - `Shared/Application/CommandHandler/AbstractCacheRefreshCommandHandler.php`
 - `Core/Customer/Application/CommandHandler/CustomerCacheRefreshCommandHandler.php`
 - `Core/Customer/Application/Factory/CustomerCacheRefreshCommandFactory.php`

--- a/.claude/skills/code-organization/reference/directory-structure.md
+++ b/.claude/skills/code-organization/reference/directory-structure.md
@@ -2,6 +2,24 @@
 
 This document provides a comprehensive reference for the project's directory structure and where each type of class belongs.
 
+## Architecture Spec Workflow
+
+When documenting a planned source tree, do not start from generic DDD names. Start from the repository:
+
+```bash
+find src/Core/{Context} -maxdepth 4 -type d | sort
+sed -n '1,140p' deptrac.yaml
+```
+
+Rules:
+
+- Reuse existing directory names for the bounded context whenever possible.
+- Keep one directory focused on one class type.
+- Extend the existing feature surface instead of adding an umbrella directory with the feature name.
+- Only propose a new directory type when no existing class type fits and deptrac will be updated and validated.
+
+Example: a Customer cache feature should not automatically create `src/Core/Customer/Infrastructure/Cache`. The current cache feature already uses `Infrastructure/Repository`, `Infrastructure/Collection`, `Infrastructure/Resolver`, and `Application/EventSubscriber`, so new cache policy and refresh classes should use existing precise directories such as `DTO`, `Factory`, `Collection`, `Resolver`, `Command`, and `CommandHandler`.
+
 ## Infrastructure Layer
 
 ```text

--- a/.claude/skills/code-organization/reference/directory-structure.md
+++ b/.claude/skills/code-organization/reference/directory-structure.md
@@ -23,8 +23,8 @@ Example: a Customer cache feature should not automatically create `src/Core/Cust
 If the cache refresh path must be reusable across bounded contexts, the generic queue payload and worker belong in Shared class-type directories, while Customer stays a first adapter:
 
 ```text
-src/Shared/Application/Command/RefreshCacheCommand.php
-src/Shared/Application/CommandHandler/RefreshCacheCommandHandler.php
+src/Shared/Application/Command/CacheRefreshCommand.php
+src/Shared/Application/CommandHandler/CacheRefreshCommandHandler.php
 src/Shared/Application/CommandHandler/AbstractCacheRefreshCommandHandler.php
 src/Shared/Application/Observability/Metric/CacheRefreshSucceededMetric.php
 src/Core/Customer/Application/CommandHandler/CustomerCacheRefreshCommandHandler.php

--- a/.claude/skills/code-organization/reference/directory-structure.md
+++ b/.claude/skills/code-organization/reference/directory-structure.md
@@ -20,6 +20,21 @@ Rules:
 
 Example: a Customer cache feature should not automatically create `src/Core/Customer/Infrastructure/Cache`. The current cache feature already uses `Infrastructure/Repository`, `Infrastructure/Collection`, `Infrastructure/Resolver`, and `Application/EventSubscriber`, so new cache policy and refresh classes should use existing precise directories such as `DTO`, `Factory`, `Collection`, `Resolver`, `Command`, and `CommandHandler`.
 
+If the cache refresh path must be reusable across bounded contexts, the generic queue payload and worker belong in Shared class-type directories, while Customer stays a first adapter:
+
+```text
+src/Shared/Application/Command/RefreshCacheCommand.php
+src/Shared/Application/CommandHandler/RefreshCacheCommandHandler.php
+src/Shared/Application/CommandHandler/AbstractCacheRefreshCommandHandler.php
+src/Shared/Application/Observability/Metric/CacheRefreshSucceededMetric.php
+src/Core/Customer/Application/CommandHandler/CustomerCacheRefreshCommandHandler.php
+src/Core/Customer/Application/Factory/CustomerCacheRefreshCommandFactory.php
+src/Core/Customer/Infrastructure/Collection/CustomerCachePolicyCollection.php
+src/Core/Customer/Infrastructure/Resolver/CustomerCachePolicyResolver.php
+```
+
+Do not route a Customer-specific command if the requirement is "one queue and worker can refresh any bounded context." Use a feature-neutral command payload with context, family, target identifiers, strategy, and event metadata, then resolve Customer-specific meaning in Customer factories, resolvers, and handlers.
+
 ## Infrastructure Layer
 
 ```text

--- a/.claude/skills/implementing-ddd-architecture/DIRECTORY-STRUCTURE.md
+++ b/.claude/skills/implementing-ddd-architecture/DIRECTORY-STRUCTURE.md
@@ -48,23 +48,28 @@ Use existing class-type directories first. A directory name is a class responsib
 - `Collection/` contains collections only.
 - `Resolver/` contains resolvers only.
 - `Repository/` contains repositories only.
-- `Metric/` contains metric classes; nested `ValueObject/` may hold metric value objects where that pattern already exists.
+- `Metric/` contains metric classes in bounded contexts; shared metrics use the existing `Shared/Application/Observability/Metric/` structure, with nested `ValueObject/` where that pattern already exists.
 
 Do not create umbrella directories such as `Cache/`, `Policy/`, `Registry/`, or `Scheduler/` inside a bounded context when the feature can be represented by existing class-type directories. If a new directory type is truly needed, update the architecture spec with the reason and validate that deptrac collects it.
 
-Example: customer cache refresh should reuse the current Customer directories:
+Example: a reusable cache refresh feature should put generic orchestration in Shared and keep Customer as an adapter:
 
 ```text
-src/Core/Customer/
+src/Shared/
   Application/
     Command/
-      RefreshCustomerCacheCommand.php
+      RefreshCacheCommand.php
     CommandHandler/
-      RefreshCustomerCacheCommandHandler.php
-    DTO/
-      CustomerCachePolicy.php
+      RefreshCacheCommandHandler.php
+      AbstractCacheRefreshCommandHandler.php
+    Observability/
+      Metric/
+        CacheRefreshSucceededMetric.php
+src/Core/Customer/
+  Application/
+    CommandHandler/
+      CustomerCacheRefreshCommandHandler.php
     Factory/
-      CustomerCachePolicyFactory.php
       CustomerCacheRefreshCommandFactory.php
   Infrastructure/
     Collection/
@@ -76,7 +81,7 @@ src/Core/Customer/
       CustomerCacheRefreshTargetResolver.php
 ```
 
-This avoids inventing `Infrastructure/Cache` for a cache feature that already exists through repository, collection, resolver, and subscriber classes.
+This avoids inventing `Infrastructure/Cache` for a context feature that already exists through repository, collection, resolver, and subscriber classes. It also avoids Customer-only queue payloads when the queue and worker must refresh cache entries for other domains later.
 
 ## Complete Directory Structure (CodelyTV Pattern)
 

--- a/.claude/skills/implementing-ddd-architecture/DIRECTORY-STRUCTURE.md
+++ b/.claude/skills/implementing-ddd-architecture/DIRECTORY-STRUCTURE.md
@@ -17,7 +17,7 @@ Is it business logic?
 ├─ Is it orchestration/use case?
 │   ├─ YES → Application layer
 │   │   ├─ Write operation? → Command + Handler (Application/Command/, Application/CommandHandler/)
-│   │   ├─ Read operation? → Query + Handler (Application/Query/, Application/QueryHandler/)
+│   │   ├─ Read operation? → Existing read path (Repository/Resolver/Processor/DTO); use Query only if the repo already has Query directories and deptrac collectors
 │   │   ├─ React to event? → Event Subscriber (Application/EventSubscriber/)
 │   │   ├─ API transformation? → DTO/Processor (Application/DTO/, Application/Processor/)
 │   │   └─ GraphQL input? → Mutation Input (Application/MutationInput/)
@@ -29,6 +29,54 @@ Is it business logic?
         ├─ Doctrine type? → Custom Type (Infrastructure/DoctrineType/)
         └─ External service? → Service Implementation (Infrastructure/Service/)
 ```
+
+## Project-First Directory Rule
+
+Before writing an architecture spec or creating files, inspect the current context and deptrac collectors:
+
+```bash
+find src/Core/{Context} -maxdepth 4 -type d | sort
+sed -n '1,140p' deptrac.yaml
+```
+
+Use existing class-type directories first. A directory name is a class responsibility, not a feature label:
+
+- `Command/` contains command objects only.
+- `CommandHandler/` contains command handlers only.
+- `DTO/` contains data-transfer objects only.
+- `Factory/` contains factories only.
+- `Collection/` contains collections only.
+- `Resolver/` contains resolvers only.
+- `Repository/` contains repositories only.
+- `Metric/` contains metric classes; nested `ValueObject/` may hold metric value objects where that pattern already exists.
+
+Do not create umbrella directories such as `Cache/`, `Policy/`, `Registry/`, or `Scheduler/` inside a bounded context when the feature can be represented by existing class-type directories. If a new directory type is truly needed, update the architecture spec with the reason and validate that deptrac collects it.
+
+Example: customer cache refresh should reuse the current Customer directories:
+
+```text
+src/Core/Customer/
+  Application/
+    Command/
+      RefreshCustomerCacheCommand.php
+    CommandHandler/
+      RefreshCustomerCacheCommandHandler.php
+    DTO/
+      CustomerCachePolicy.php
+    Factory/
+      CustomerCachePolicyFactory.php
+      CustomerCacheRefreshCommandFactory.php
+  Infrastructure/
+    Collection/
+      CustomerCachePolicyCollection.php
+    Repository/
+      CachedCustomerRepository.php
+    Resolver/
+      CustomerCachePolicyResolver.php
+      CustomerCacheRefreshTargetResolver.php
+```
+
+This avoids inventing `Infrastructure/Cache` for a cache feature that already exists through repository, collection, resolver, and subscriber classes.
 
 ## Complete Directory Structure (CodelyTV Pattern)
 

--- a/.claude/skills/implementing-ddd-architecture/DIRECTORY-STRUCTURE.md
+++ b/.claude/skills/implementing-ddd-architecture/DIRECTORY-STRUCTURE.md
@@ -58,9 +58,9 @@ Example: a reusable cache refresh feature should put generic orchestration in Sh
 src/Shared/
   Application/
     Command/
-      RefreshCacheCommand.php
+      CacheRefreshCommand.php
     CommandHandler/
-      RefreshCacheCommandHandler.php
+      CacheRefreshCommandHandler.php
       AbstractCacheRefreshCommandHandler.php
     Observability/
       Metric/

--- a/.claude/skills/implementing-ddd-architecture/REFERENCE.md
+++ b/.claude/skills/implementing-ddd-architecture/REFERENCE.md
@@ -110,7 +110,7 @@ class Customer extends AggregateRoot
 - **Transformers**: Convert between representations
 - **API Platform Processors**: Handle API operations
 - **GraphQL Resolvers**: Handle GraphQL queries/mutations
-- **Message Handlers**: Process async messages
+- **Command Handlers**: Process commands; async delivery can still use command classes when that matches the existing CQRS structure
 - **Factory Implementations**: Build domain objects from external data
 
 **Rules**:

--- a/.claude/skills/implementing-ddd-architecture/REFERENCE.md
+++ b/.claude/skills/implementing-ddd-architecture/REFERENCE.md
@@ -104,13 +104,12 @@ class Customer extends AggregateRoot
 
 **Contains**:
 
-- **Command Handlers**: Execute write operations (implement `CommandHandlerInterface`)
+- **Command Handlers**: Execute write operations and process commands (implement `CommandHandlerInterface`); async delivery can still use command classes when that matches the existing CQRS structure
 - **Event Subscribers**: React to domain events (implement `DomainEventSubscriberInterface`)
 - **DTOs**: Data transfer between layers (validation via YAML config at `config/validator/`)
 - **Transformers**: Convert between representations
 - **API Platform Processors**: Handle API operations
 - **GraphQL Resolvers**: Handle GraphQL queries/mutations
-- **Command Handlers**: Process commands; async delivery can still use command classes when that matches the existing CQRS structure
 - **Factory Implementations**: Build domain objects from external data
 
 **Rules**:

--- a/.claude/skills/implementing-ddd-architecture/SKILL.md
+++ b/.claude/skills/implementing-ddd-architecture/SKILL.md
@@ -57,12 +57,16 @@ Do not propose `ReadModel`, `Query`, `QueryHandler`, `Message`, `MessageHandler`
 
 Example for Customer cache planning:
 
-- Refresh work: `Application/Command/RefreshCustomerCacheCommand.php`
-- Refresh execution: `Application/CommandHandler/RefreshCustomerCacheCommandHandler.php`
-- Policy data: `Application/DTO/CustomerCachePolicy.php`
-- Policy creation: `Application/Factory/CustomerCachePolicyFactory.php`
-- Policy lookup: `Infrastructure/Collection/CustomerCachePolicyCollection.php` plus `Infrastructure/Resolver/CustomerCachePolicyResolver.php`
-- Cached storage access: existing `Infrastructure/Repository/CachedCustomerRepository.php`
+- Shared reusable refresh work: `Shared/Application/Command/RefreshCacheCommand.php`
+- Shared reusable worker: `Shared/Application/CommandHandler/RefreshCacheCommandHandler.php`
+- Shared reusable handler base: `Shared/Application/CommandHandler/AbstractCacheRefreshCommandHandler.php`
+- Shared reusable metrics: `Shared/Application/Observability/Metric/CacheRefreshSucceededMetric.php`
+- Customer adapter execution: `Core/Customer/Application/CommandHandler/CustomerCacheRefreshCommandHandler.php`
+- Customer adapter factory: `Core/Customer/Application/Factory/CustomerCacheRefreshCommandFactory.php`
+- Customer policy lookup: `Core/Customer/Infrastructure/Collection/CustomerCachePolicyCollection.php` plus `Core/Customer/Infrastructure/Resolver/CustomerCachePolicyResolver.php`
+- Customer cached storage access: existing `Core/Customer/Infrastructure/Repository/CachedCustomerRepository.php`
+
+When a feature must be reusable across bounded contexts, put the generic command, worker, abstract base classes, DTOs, resolver interfaces, and metrics in `Shared` first. Keep each bounded context as a thin adapter that maps its domain events, tags, targets, policies, and repository warmup behavior into the shared contract. Do not route Customer-specific command payloads if the same queue and worker must later refresh other domains.
 
 ---
 

--- a/.claude/skills/implementing-ddd-architecture/SKILL.md
+++ b/.claude/skills/implementing-ddd-architecture/SKILL.md
@@ -35,6 +35,37 @@ Business logic belongs in the Domain layer. Application layer orchestrates, Doma
 
 ---
 
+## Architecture Planning: Existing Structure First
+
+When writing architecture specs or proposing new classes for this repository, inspect the current source tree and `deptrac.yaml` before inventing directories.
+
+Required workflow:
+
+1. List existing directories for the bounded context, for example `find src/Core/Customer -maxdepth 4 -type d | sort`.
+2. Check `deptrac.yaml` collectors for allowed Application, Domain, and Infrastructure directory names.
+3. Reuse existing type directories whenever they already express the class responsibility.
+4. Keep the rule **one directory = one class type**. Do not place policies, schedulers, registries, handlers, DTOs, and resolvers together in a broad feature bucket.
+5. If a feature already exists through `Repository`, `Collection`, `Resolver`, `EventSubscriber`, or other established directories, extend that feature surface instead of creating a new umbrella directory such as `Cache`.
+6. Introduce a new directory type only when no existing type fits, it is added to deptrac, and the architecture spec explains why the new type is necessary.
+
+For CQRS in this codebase, prefer:
+
+- `Application/Command/{Action}{Entity}Command.php`
+- `Application/CommandHandler/{Action}{Entity}CommandHandler.php`
+
+Do not propose `ReadModel`, `Query`, `QueryHandler`, `Message`, `MessageHandler`, `Policy`, `Registry`, or `Scheduler` directories unless the current repo already uses that directory type and deptrac collects it. Reads in the current Customer context are served by repositories, resolvers, processors, and DTOs rather than a separate read-model directory.
+
+Example for Customer cache planning:
+
+- Refresh work: `Application/Command/RefreshCustomerCacheCommand.php`
+- Refresh execution: `Application/CommandHandler/RefreshCustomerCacheCommandHandler.php`
+- Policy data: `Application/DTO/CustomerCachePolicy.php`
+- Policy creation: `Application/Factory/CustomerCachePolicyFactory.php`
+- Policy lookup: `Infrastructure/Collection/CustomerCachePolicyCollection.php` plus `Infrastructure/Resolver/CustomerCachePolicyResolver.php`
+- Cached storage access: existing `Infrastructure/Repository/CachedCustomerRepository.php`
+
+---
+
 ## Layer Dependency Rules
 
 ```
@@ -292,6 +323,8 @@ final readonly class CustomerNameChangedSubscriber implements DomainEventSubscri
 - Modify `deptrac.yaml` to allow violations
 - Skip validation (either in Value Objects or YAML config)
 - Use public setters in entities
+- Create a new feature bucket directory when existing class-type directories fit
+- Propose directories that deptrac does not collect without explicitly updating and validating deptrac
 
 ### ALWAYS
 
@@ -302,6 +335,8 @@ final readonly class CustomerNameChangedSubscriber implements DomainEventSubscri
 - Implement repositories in Infrastructure layer
 - Use Command Bus for write operations
 - Record Domain Events for state changes
+- Reuse existing bounded-context directory names before adding new ones
+- Keep one directory focused on one class type
 - Verify with `make deptrac` after changes
 
 ---

--- a/.claude/skills/implementing-ddd-architecture/SKILL.md
+++ b/.claude/skills/implementing-ddd-architecture/SKILL.md
@@ -57,8 +57,8 @@ Do not propose `ReadModel`, `Query`, `QueryHandler`, `Message`, `MessageHandler`
 
 Example for Customer cache planning:
 
-- Shared reusable refresh work: `Shared/Application/Command/RefreshCacheCommand.php`
-- Shared reusable worker: `Shared/Application/CommandHandler/RefreshCacheCommandHandler.php`
+- Shared reusable refresh work: `Shared/Application/Command/CacheRefreshCommand.php`
+- Shared reusable worker: `Shared/Application/CommandHandler/CacheRefreshCommandHandler.php`
 - Shared reusable handler base: `Shared/Application/CommandHandler/AbstractCacheRefreshCommandHandler.php`
 - Shared reusable metrics: `Shared/Application/Observability/Metric/CacheRefreshSucceededMetric.php`
 - Customer adapter execution: `Core/Customer/Application/CommandHandler/CustomerCacheRefreshCommandHandler.php`

--- a/specs/issue-176-async-cache-refresh/README.md
+++ b/specs/issue-176-async-cache-refresh/README.md
@@ -1,6 +1,6 @@
-# Issue 176 Planning Specs
+# Issue 176 Abstract Cache Refresh Planning Specs
 
-Planning bundle for GitHub issue #176, "Implement endpoint cache invalidation with async background refresh via SQS workers".
+Planning bundle for GitHub issue #176, "Implement endpoint cache invalidation with async background refresh via SQS workers", framed as a shared reusable cache-refresh foundation with Customer as the first adopter.
 
 ## Artifacts
 

--- a/specs/issue-176-async-cache-refresh/README.md
+++ b/specs/issue-176-async-cache-refresh/README.md
@@ -1,6 +1,6 @@
 # Issue 176 Abstract Cache Refresh Planning Specs
 
-Planning bundle for GitHub issue #176, "Implement endpoint cache invalidation with async background refresh via SQS workers", framed as a shared reusable cache-refresh foundation with Customer as the first adopter.
+Planning bundle for GitHub issue #176, "Implement endpoint cache invalidation with async background refresh via SQS workers", framed as shared automatic CRUD invalidation plus reusable async cache refresh with Customer as the first adopter.
 
 ## Artifacts
 

--- a/specs/issue-176-async-cache-refresh/README.md
+++ b/specs/issue-176-async-cache-refresh/README.md
@@ -1,0 +1,18 @@
+# Issue 176 Planning Specs
+
+Planning bundle for GitHub issue #176, "Implement endpoint cache invalidation with async background refresh via SQS workers".
+
+## Artifacts
+
+- [Research](research.md)
+- [Product Brief](product-brief.md)
+- [Product Brief Distillate](product-brief-distillate.md)
+- [PRD](prd.md)
+- [Architecture](architecture.md)
+- [Epics and Stories](epics.md)
+- [Implementation Readiness](implementation-readiness.md)
+- [Run Summary](run-summary.md)
+
+## Scope
+
+These specs are planning-only. They do not implement the feature.

--- a/specs/issue-176-async-cache-refresh/README.md
+++ b/specs/issue-176-async-cache-refresh/README.md
@@ -1,6 +1,6 @@
 # Issue 176 Abstract Cache Refresh Planning Specs
 
-Planning bundle for GitHub issue #176, "Implement endpoint cache invalidation with async background refresh via SQS workers", framed as shared automatic CRUD invalidation plus reusable async cache refresh with Customer as the first adopter.
+Planning bundle for GitHub issue #176, "Implement endpoint cache invalidation with async background refresh via SQS workers", framed as shared layered invalidation plus reusable async cache refresh with Customer as the first adopter.
 
 ## Artifacts
 

--- a/specs/issue-176-async-cache-refresh/architecture.md
+++ b/specs/issue-176-async-cache-refresh/architecture.md
@@ -2,14 +2,18 @@
 
 ## Current Architecture Fit
 
-The implementation should extend the existing hexagonal/CQRS setup:
+The implementation should extend the existing Customer feature directories instead of creating a new `src/Core/Customer/Infrastructure/Cache` bucket:
 
 - Domain events stay in `src/Core/Customer/Domain/Event`.
 - Event subscribers stay in `src/Core/Customer/Application/EventSubscriber`.
-- Cache policy, scheduling, and refresh handling belong in `Infrastructure/Cache` because they coordinate Symfony Cache, Messenger, and Redis/SQS concerns.
-- Application subscribers can call Infrastructure cache services under the current deptrac rules, but new classes must still use directories captured by `deptrac.yaml`.
-- Cache repository decorator remains in `Infrastructure/Repository`.
-- Messenger transport and handler wiring stay in Symfony configuration.
+- Async cache refresh should be modeled as CQRS command flow with `Application/Command` and `Application/CommandHandler`.
+- Cache policy data belongs in existing Application and Infrastructure type directories: `DTO`, `Factory`, `Collection`, and `Resolver`.
+- The cached repository decorator remains the feature anchor in `Infrastructure/Repository`.
+- Existing cache tag helpers remain in `Infrastructure/Collection` and `Infrastructure/Resolver`.
+- Shared low-level cache utilities remain in `src/Shared/Infrastructure/Cache`.
+- Do not introduce `ReadModel`, `Query`, `Policy`, `Registry`, `Scheduler`, `Message`, or `MessageHandler` directories for this feature unless the current repo already contains and collects those directory types.
+
+This structure follows the repository rule: one directory contains one class type, and planning must prefer existing directory names that are already represented in the source tree and `deptrac.yaml`.
 
 ## Architecture Diagram
 
@@ -21,18 +25,21 @@ flowchart LR
 
     subgraph Application["Customer Application layer"]
         Subscribers["Customer cache invalidation subscribers"]
-        Message["CustomerCacheRefreshMessage"]
+        CommandFactory["CustomerCacheRefreshCommandFactory"]
+        RefreshCommand["RefreshCustomerCacheCommand"]
+        RefreshHandler["RefreshCustomerCacheCommandHandler"]
+        PolicyDto["CustomerCachePolicy DTO"]
         Metrics["Customer cache metric classes"]
     end
 
-    subgraph Infrastructure["Infrastructure layer"]
-        PolicyRegistry["CustomerCachePolicyRegistry"]
-        Scheduler["CustomerCacheRefreshScheduler"]
-        Handler["CustomerCacheRefreshMessageHandler"]
+    subgraph Infrastructure["Customer Infrastructure layer"]
+        PolicyCollection["CustomerCachePolicyCollection"]
+        PolicyResolver["CustomerCachePolicyResolver"]
+        TargetResolver["CustomerCacheRefreshTargetResolver"]
         CachedRepo["CachedCustomerRepository"]
         InnerRepo["MongoCustomerRepository"]
-        KeyBuilder["CacheKeyBuilder"]
         TagResolver["CustomerCacheTagResolver"]
+        KeyBuilder["CacheKeyBuilder"]
         CachePools["Redis tag-aware cache pools\ncustomer detail, lookup, collection, reference"]
         Messenger["Symfony Messenger"]
         Sqs["SQS transport\nLocalStack locally"]
@@ -47,69 +54,86 @@ flowchart LR
     Messenger --> Subscribers
     Subscribers --> TagResolver
     Subscribers --> CachePools
-    Subscribers --> Scheduler
-    Scheduler --> PolicyRegistry
-    Scheduler --> Message
-    Message --> Messenger
+    Subscribers --> TargetResolver
+    Subscribers --> CommandFactory
+    CommandFactory --> RefreshCommand
+    Subscribers --> Messenger
     Messenger --> Sqs
-    Sqs --> Handler
-    Handler --> PolicyRegistry
-    Handler --> InnerRepo
-    Handler --> KeyBuilder
-    Handler --> CachePools
+    Sqs --> RefreshCommand
+    RefreshCommand --> RefreshHandler
+    RefreshHandler --> PolicyResolver
+    PolicyResolver --> PolicyCollection
+    RefreshHandler --> InnerRepo
+    RefreshHandler --> KeyBuilder
+    RefreshHandler --> CachePools
 
     ReadApi["Customer read API"] --> CachedRepo
-    CachedRepo --> PolicyRegistry
+    CachedRepo --> PolicyResolver
     CachedRepo --> KeyBuilder
     CachedRepo --> CachePools
     CachedRepo --> InnerRepo
 
     CachedRepo --> Metrics
-    Scheduler --> Metrics
-    Handler --> Metrics
+    Subscribers --> Metrics
+    RefreshHandler --> Metrics
     Metrics --> Emitter
 ```
 
-Read requests continue to use the cache repository decorator. Write-side domain events invalidate affected tags and schedule same-entity refresh messages. Refresh workers warm customer detail and email lookup cache entries through the inner repository without blocking business writes.
+Read requests continue to use the cache repository decorator. Write-side domain events invalidate affected tags and enqueue `RefreshCustomerCacheCommand` work for same-entity cache refresh. Refresh workers warm customer detail and email lookup cache entries through the inner repository without blocking business writes.
 
 ## Planned Source Tree
 
-The implementation PR should add the following source files. Existing files that need edits are listed separately below.
+The implementation PR should add the following source files and edit the listed existing feature files.
 
 ```text
 src/
   Core/
     Customer/
       Application/
-        Message/
-          CustomerCacheRefreshMessage.php
+        Command/
+          RefreshCustomerCacheCommand.php
+        CommandHandler/
+          RefreshCustomerCacheCommandHandler.php
+        DTO/
+          CustomerCachePolicy.php
+        EventSubscriber/
+          CustomerCreatedCacheInvalidationSubscriber.php (edit)
+          CustomerDeletedCacheInvalidationSubscriber.php (edit)
+          CustomerUpdatedCacheInvalidationSubscriber.php (edit)
+        Factory/
+          CustomerCachePolicyFactory.php
+          CustomerCacheRefreshCommandFactory.php
         Metric/
           CustomerCacheHitMetric.php
-          CustomerCacheMetricDimensions.php
           CustomerCacheMissMetric.php
           CustomerCacheRefreshFailedMetric.php
           CustomerCacheRefreshScheduledMetric.php
           CustomerCacheRefreshSucceededMetric.php
           CustomerCacheStaleServedMetric.php
+          ValueObject/
+            CustomerCacheMetricDimensions.php
       Infrastructure/
-        Cache/
-          CustomerCacheConsistency.php
-          CustomerCacheFamily.php
-          CustomerCachePolicy.php
+        Collection/
           CustomerCachePolicyCollection.php
-          CustomerCachePolicyRegistry.php
-          CustomerCachePolicyRegistryInterface.php
-          CustomerCacheRefreshMessageHandler.php
-          CustomerCacheRefreshScheduler.php
-          CustomerCacheRefreshSchedulerInterface.php
-          CustomerCacheRefreshStrategy.php
+          CustomerCacheTagCollection.php (existing)
+        Repository/
+          CachedCustomerRepository.php (edit)
+        Resolver/
+          CustomerCachePolicyResolver.php
+          CustomerCacheRefreshTargetResolver.php
+          CustomerCacheTagResolver.php (existing)
+  Shared/
+    Infrastructure/
+      Cache/
+        CacheKeyBuilder.php (existing, edit only for generic key helpers)
 ```
 
-This layout matches the existing `deptrac.yaml` collectors:
+This layout matches current source and deptrac boundaries:
 
-- `Application/Message` and `Application/Metric` are collected as Application.
-- `Infrastructure/Cache` is collected as Infrastructure.
-- `Application/Cache`, `Application/Scheduler`, and `Application/MessageHandler` are intentionally avoided because they are not collected by the current deptrac configuration.
+- `Application/Command`, `Application/CommandHandler`, `Application/DTO`, `Application/EventSubscriber`, `Application/Factory`, and `Application/Metric` are already collected as Application.
+- `Infrastructure/Collection`, `Infrastructure/Repository`, and `Infrastructure/Resolver` are already collected as Infrastructure.
+- `Shared/Infrastructure/Cache` already exists for shared cache utilities.
+- No new Customer `Infrastructure/Cache` directory is needed because cache behavior is part of the existing Customer repository, collection, resolver, and subscriber feature surface.
 
 Planned test files:
 
@@ -118,30 +142,39 @@ tests/
   Unit/
     Customer/
       Application/
+        Command/
+          RefreshCustomerCacheCommandTest.php
+        CommandHandler/
+          RefreshCustomerCacheCommandHandlerTest.php
+        DTO/
+          CustomerCachePolicyTest.php
         EventSubscriber/
           CustomerCreatedCacheInvalidationSubscriberTest.php
           CustomerDeletedCacheInvalidationSubscriberTest.php
           CustomerUpdatedCacheInvalidationSubscriberTest.php
-        Message/
-          CustomerCacheRefreshMessageTest.php
+        Factory/
+          CustomerCachePolicyFactoryTest.php
+          CustomerCacheRefreshCommandFactoryTest.php
         Metric/
           CustomerCacheMetricTest.php
+          ValueObject/
+            CustomerCacheMetricDimensionsTest.php
       Infrastructure/
-        Cache/
-          CustomerCachePolicyRegistryTest.php
-          CustomerCachePolicyTest.php
-          CustomerCacheRefreshMessageHandlerTest.php
-          CustomerCacheRefreshSchedulerTest.php
+        Collection/
+          CustomerCachePolicyCollectionTest.php
         Repository/
           CachedCustomerRepositoryPolicyTest.php
+        Resolver/
+          CustomerCachePolicyResolverTest.php
+          CustomerCacheRefreshTargetResolverTest.php
   Integration/
     Customer/
       Infrastructure/
-        Cache/
+        Repository/
           AsyncCustomerCacheRefreshTest.php
 ```
 
-Configuration and existing files expected to change:
+Configuration and documentation expected to change:
 
 ```text
 config/
@@ -154,17 +187,6 @@ config/
   services.yaml
 .env
 .env.test
-src/
-  Core/
-    Customer/
-      Application/
-        EventSubscriber/
-          CustomerCreatedCacheInvalidationSubscriber.php
-          CustomerDeletedCacheInvalidationSubscriber.php
-          CustomerUpdatedCacheInvalidationSubscriber.php
-      Infrastructure/
-        Repository/
-          CachedCustomerRepository.php
 docs/
   advanced-configuration.md
   design-and-architecture.md
@@ -176,27 +198,25 @@ docs/
 
 ### Cache Policy Model
 
-Add typed policy classes in `src/Core/Customer/Infrastructure/Cache`:
+Add cache policy classes through existing class-type directories:
 
-- `CustomerCacheFamily`
-- `CustomerCacheConsistency`
-- `CustomerCacheRefreshStrategy`
-- `CustomerCachePolicy`
-- `CustomerCachePolicyRegistry`
-- `CustomerCachePolicyRegistryInterface`
-- optional typed collection for registry construction
+- `CustomerCachePolicy` in `Application/DTO`
+- `CustomerCachePolicyFactory` in `Application/Factory`
+- `CustomerCachePolicyCollection` in `Infrastructure/Collection`
+- `CustomerCachePolicyResolver` in `Infrastructure/Resolver`
 
-Use services.yaml arguments for TTLs/jitter so defaults are configurable without editing repository code.
+Use services.yaml arguments for TTLs and jitter so defaults are configurable without editing repository code. Avoid separate enum classes in the first implementation unless the implementation already has an existing enum directory pattern to reuse.
 
-### Cache Refresh Message Path
+### Cache Refresh Command Path
 
-Add a dedicated message model:
+Add a dedicated command model instead of a separate message model:
 
-- `CustomerCacheRefreshMessage` in `src/Core/Customer/Application/Message`
-- `CustomerCacheRefreshMessageHandler` in `src/Core/Customer/Infrastructure/Cache`
-- `CustomerCacheRefreshScheduler` in `src/Core/Customer/Infrastructure/Cache`
+- `RefreshCustomerCacheCommand` in `Application/Command`
+- `RefreshCustomerCacheCommandHandler` in `Application/CommandHandler`
+- `CustomerCacheRefreshCommandFactory` in `Application/Factory`
+- `CustomerCacheRefreshTargetResolver` in `Infrastructure/Resolver`
 
-The message should carry scalar payload only, such as family name, customer ID, email, and event metadata, so it remains stable across Messenger serialization. The scheduler dispatches messages through `MessageBusInterface` and catches dispatch failures. The handler warms same-entity entries from the underlying persisted state, such as customer detail by ID and lookup by email. For delete events, it should avoid warming deleted entities and may schedule only collection/reference policy refresh markers where safe.
+The command should carry scalar payload only, such as family name, customer ID, email, and event metadata, so it remains stable across Messenger serialization. Event subscribers create refresh commands after invalidation and dispatch them best-effort through Messenger or the configured command path. The handler warms same-entity entries from persisted state, such as customer detail by ID and lookup by email. For delete events, it should avoid warming deleted entities and may only preserve invalidation behavior.
 
 ### Repository Decorator Changes
 
@@ -204,10 +224,10 @@ Update `CachedCustomerRepository` to inject:
 
 - detail cache pool
 - lookup cache pool
-- policy registry
+- policy resolver
 - metrics emitter or cache metrics service
 
-Use the policy registry for TTL, tags, and cache key metadata. Preserve existing `findFresh()` bypass behavior for write paths.
+Use the policy resolver for TTL, tags, and cache key metadata. Preserve existing `findFresh()` bypass behavior for write paths.
 
 ### Messenger Configuration
 
@@ -219,13 +239,13 @@ Add:
 - `FAILED_CACHE_REFRESH_TRANSPORT_DSN`
 - `cache-refresh` transport
 - `failed-cache-refresh` transport
-- routing for `CustomerCacheRefreshMessage`
+- routing for `RefreshCustomerCacheCommand`
 
-In `when@test`, route cache refresh to in-memory transport.
+In `when@test`, route cache refresh to an in-memory transport.
 
 ### Observability
 
-Add typed metrics under `src/Core/Customer/Application/Metric` or shared observability if reusable:
+Add typed metrics under `src/Core/Customer/Application/Metric`:
 
 - `CustomerCacheRefreshScheduledMetric`
 - `CustomerCacheRefreshSucceededMetric`
@@ -234,21 +254,21 @@ Add typed metrics under `src/Core/Customer/Application/Metric` or shared observa
 - `CustomerCacheMissMetric`
 - `CustomerCacheStaleServedMetric`
 
-Prefer a `CustomerCacheMetricDimensions` value object with `Endpoint=CustomerCache`, `Operation=<operation>`, `Family=<family>`.
+Place metric dimension value objects under `Application/Metric/ValueObject` so metric classes and value objects do not share one directory.
 
 ### Failure Semantics
 
 - Repository cache failures fall back to the inner repository.
-- Scheduler failures log and emit a failure metric, then return.
-- Handler failures log and emit a failure metric, then return so poison refresh jobs do not block business behavior.
+- Subscriber dispatch failures log and emit a failure metric, then return.
+- Command handler failures log and emit a failure metric, then return so poison refresh jobs do not block business behavior.
 - Domain event subscribers remain resilient through the existing `DomainEventMessageHandler`.
 
 ## Implementation Sequence
 
-1. Add policy model and tests.
+1. Add policy DTO, factory, collection, resolver, and tests.
 2. Split cache pools and update repository TTL usage.
-3. Add refresh message/scheduler/handler and Messenger routing.
-4. Update subscribers to invalidate plus schedule.
+3. Add refresh command, command factory, command handler, target resolver, and Messenger routing.
+4. Update subscribers to invalidate plus dispatch refresh commands.
 5. Add metrics and tests.
 6. Add integration proof and docs.
 7. Run CI and cache performance evidence.

--- a/specs/issue-176-async-cache-refresh/architecture.md
+++ b/specs/issue-176-async-cache-refresh/architecture.md
@@ -1,119 +1,202 @@
-# Architecture: Async Endpoint Cache Refresh
+# Architecture: Abstract Async Endpoint Cache Refresh
 
 ## Current Architecture Fit
 
-The implementation should extend the existing Customer feature directories instead of creating a new `src/Core/Customer/Infrastructure/Cache` bucket:
+Issue #176 should introduce a reusable cache-refresh foundation, not a Customer-only worker design. Customer is the first adopter because it already has cached repository reads and domain-event cache invalidation subscribers, but the refresh command, queue, worker, metrics, and abstract orchestration must be reusable by future bounded contexts.
 
-- Domain events stay in `src/Core/Customer/Domain/Event`.
-- Event subscribers stay in `src/Core/Customer/Application/EventSubscriber`.
-- Async cache refresh should be modeled as CQRS command flow with `Application/Command` and `Application/CommandHandler`.
-- Cache policy data belongs in existing Application and Infrastructure type directories: `DTO`, `Factory`, `Collection`, and `Resolver`.
-- The cached repository decorator remains the feature anchor in `Infrastructure/Repository`.
-- Existing cache tag helpers remain in `Infrastructure/Collection` and `Infrastructure/Resolver`.
-- Shared low-level cache utilities remain in `src/Shared/Infrastructure/Cache`.
-- Do not introduce `ReadModel`, `Query`, `Policy`, `Registry`, `Scheduler`, `Message`, or `MessageHandler` directories for this feature unless the current repo already contains and collects those directory types.
+The current repository already has the right primitives:
 
-This structure follows the repository rule: one directory contains one class type, and planning must prefer existing directory names that are already represented in the source tree and `deptrac.yaml`.
+- Any domain event can flow through `Shared/Infrastructure/Bus/Event/Async/DomainEventEnvelope`.
+- `Shared/Infrastructure/Bus/Event/Async/DomainEventMessageHandler` already reads domain events from the async event transport and invokes tagged subscribers.
+- CQRS command objects and handlers already live in `Application/Command` and `Application/CommandHandler`.
+- `Shared/Application/Command` already exists, and deptrac collects `Application/Command` and `Application/CommandHandler`.
+- Shared metrics already live in `Shared/Application/Observability/Metric`.
+- Shared cache utilities already live in `Shared/Infrastructure/Cache`.
+- Context-specific cache behavior already appears as repository decorators, collections, resolvers, factories, and event subscribers.
+
+The implementation should add shared abstractions and thin context adapters. It should not add Customer-only queue contracts that future domains would need to copy.
+
+## Directory Rules
+
+This plan follows the repository rule: one directory contains one class type.
+
+- Put the reusable refresh command in `src/Shared/Application/Command`.
+- Put reusable refresh command handlers and abstract handler bases in `src/Shared/Application/CommandHandler`.
+- Put reusable DTOs, resolver interfaces, event-subscriber bases, factories, and metrics in their matching class-type directories.
+- Put reusable metrics under `src/Shared/Application/Observability/Metric`, matching the existing shared observability structure.
+- Put reusable infrastructure collaborators in existing or deptrac-collected class-type directories such as `src/Shared/Infrastructure/{Cache,Collection,Resolver}`.
+- Put bounded-context adapters in existing context directories such as `src/Core/Customer/Application/{CommandHandler,EventSubscriber,Factory}` and `src/Core/Customer/Infrastructure/{Collection,Repository,Resolver}`.
+- Do not introduce new context directories named `Cache`, `ReadModel`, `Policy`, `Registry`, `Scheduler`, `Message`, or `MessageHandler`.
+- Do not create a Customer `Infrastructure/Cache` directory. Cache refresh is part of the existing repository, collection, resolver, subscriber, factory, command, and handler surface.
 
 ## Architecture Diagram
 
 ```mermaid
 flowchart LR
-    subgraph Domain["Domain layer (framework-free)"]
-        DomainEvents["CustomerCreatedEvent\nCustomerUpdatedEvent\nCustomerDeletedEvent"]
+    subgraph Domain["Any bounded-context Domain layer"]
+        DomainEvent["DomainEvent\nCustomerCreatedEvent\nFutureContextEvent"]
     end
 
-    subgraph Application["Customer Application layer"]
-        Subscribers["Customer cache invalidation subscribers"]
-        CommandFactory["CustomerCacheRefreshCommandFactory"]
-        RefreshCommand["RefreshCustomerCacheCommand"]
-        RefreshHandler["RefreshCustomerCacheCommandHandler"]
-        PolicyDto["CustomerCachePolicy DTO"]
-        Metrics["Customer cache metric classes"]
+    subgraph DomainEventWorker["Shared async domain-event path"]
+        EventEnvelope["DomainEventEnvelope"]
+        EventQueue["domain-events SQS transport\nLocalStack locally"]
+        EventWorker["DomainEventMessageHandler\nreads any domain event"]
     end
 
-    subgraph Infrastructure["Customer Infrastructure layer"]
-        PolicyCollection["CustomerCachePolicyCollection"]
-        PolicyResolver["CustomerCachePolicyResolver"]
-        TargetResolver["CustomerCacheRefreshTargetResolver"]
-        CachedRepo["CachedCustomerRepository"]
-        InnerRepo["MongoCustomerRepository"]
-        TagResolver["CustomerCacheTagResolver"]
+    subgraph SharedRefresh["Shared cache-refresh foundation"]
+        AbstractSubscriber["AbstractCacheInvalidationSubscriber"]
+        AbstractFactory["AbstractCacheRefreshCommandFactory"]
+        RefreshCommand["RefreshCacheCommand\nscalar reusable payload"]
+        RefreshWorker["RefreshCacheCommandHandler\nsingle shared worker"]
+        AbstractHandler["AbstractCacheRefreshCommandHandler"]
+        PolicyDto["CacheRefreshPolicy DTO"]
+        TargetDto["CacheRefreshTarget DTO"]
+        ResultDto["CacheRefreshResult DTO"]
+        HandlerResolver["CacheRefreshCommandHandlerResolver"]
+        PolicyResolver["CacheRefreshPolicyResolver"]
+        TargetResolver["CacheRefreshTargetResolverCollection"]
         KeyBuilder["CacheKeyBuilder"]
-        CachePools["Redis tag-aware cache pools\ncustomer detail, lookup, collection, reference"]
-        Messenger["Symfony Messenger"]
-        Sqs["SQS transport\nLocalStack locally"]
+        Metrics["Shared cache-refresh metrics"]
+    end
+
+    subgraph CustomerAdapter["Customer first adopter"]
+        CustomerSubscriber["Customer cache invalidation subscribers"]
+        CustomerFactory["CustomerCacheRefreshCommandFactory"]
+        CustomerHandler["CustomerCacheRefreshCommandHandler\nregistered adapter"]
+        CustomerTargetResolver["CustomerCacheRefreshTargetResolver"]
+        CustomerPolicyCollection["CustomerCachePolicyCollection"]
+        CachedCustomerRepository["CachedCustomerRepository"]
+        CustomerRepository["MongoCustomerRepository"]
+    end
+
+    subgraph FutureAdapter["Future bounded-context adopter"]
+        FutureSubscriber["Future context subscriber"]
+        FutureFactory["Future context command factory"]
+        FutureHandler["Future context refresh handler"]
+        FutureRepository["Future cached repository"]
+    end
+
+    subgraph RefreshTransport["Shared cache-refresh queue"]
+        RefreshQueue["cache-refresh SQS transport\nLocalStack locally"]
+        FailedQueue["failed-cache-refresh transport"]
+        MessengerWorkers["Symfony Messenger workers"]
+    end
+
+    subgraph Runtime["Cache runtime"]
+        CachePools["Redis tag-aware cache pools\ncontext + family scoped"]
     end
 
     subgraph Observability["Shared observability"]
         Emitter["BusinessMetricsEmitterInterface"]
     end
 
-    WriteApi["Customer write API\ncommand handlers"] --> DomainEvents
-    DomainEvents --> Messenger
-    Messenger --> Subscribers
-    Subscribers --> TagResolver
-    Subscribers --> CachePools
-    Subscribers --> TargetResolver
-    Subscribers --> CommandFactory
-    CommandFactory --> RefreshCommand
-    Subscribers --> Messenger
-    Messenger --> Sqs
-    Sqs --> RefreshCommand
-    RefreshCommand --> RefreshHandler
-    RefreshHandler --> PolicyResolver
-    PolicyResolver --> PolicyCollection
-    PolicyResolver --> PolicyDto
-    RefreshHandler --> PolicyDto
-    RefreshHandler --> InnerRepo
-    RefreshHandler --> KeyBuilder
-    RefreshHandler --> CachePools
+    WriteApi["Any write API\ncommand handlers"] --> DomainEvent
+    DomainEvent --> EventEnvelope
+    EventEnvelope --> EventQueue
+    EventQueue --> EventWorker
 
-    ReadApi["Customer read API"] --> CachedRepo
-    CachedRepo --> PolicyResolver
-    CachedRepo --> KeyBuilder
-    CachedRepo --> CachePools
-    CachedRepo --> InnerRepo
+    EventWorker --> CustomerSubscriber
+    EventWorker --> FutureSubscriber
 
-    CachedRepo --> Metrics
-    Subscribers --> Metrics
-    RefreshHandler --> Metrics
+    CustomerSubscriber --> AbstractSubscriber
+    FutureSubscriber --> AbstractSubscriber
+    AbstractSubscriber --> CachePools
+    AbstractSubscriber --> TargetResolver
+    CustomerTargetResolver --> TargetResolver
+    AbstractSubscriber --> AbstractFactory
+    CustomerFactory --> AbstractFactory
+    FutureFactory --> AbstractFactory
+    AbstractFactory --> RefreshCommand
+    RefreshCommand --> RefreshQueue
+
+    RefreshQueue --> MessengerWorkers
+    MessengerWorkers --> RefreshWorker
+    RefreshWorker --> HandlerResolver
+    HandlerResolver --> CustomerHandler
+    HandlerResolver --> FutureHandler
+    CustomerHandler --> AbstractHandler
+    FutureHandler --> AbstractHandler
+    AbstractHandler --> PolicyResolver
+    PolicyResolver --> CustomerPolicyCollection
+    AbstractHandler --> TargetResolver
+    TargetResolver --> TargetDto
+    AbstractHandler --> PolicyDto
+    AbstractHandler --> KeyBuilder
+    CustomerHandler --> CustomerRepository
+    CustomerHandler --> CachePools
+    AbstractHandler --> ResultDto
+    RefreshWorker --> FailedQueue
+
+    ReadApi["Customer read API"] --> CachedCustomerRepository
+    CachedCustomerRepository --> PolicyResolver
+    CachedCustomerRepository --> KeyBuilder
+    CachedCustomerRepository --> CachePools
+    CachedCustomerRepository --> CustomerRepository
+    FutureReadApi["Future read API"] --> FutureRepository
+
+    AbstractSubscriber --> Metrics
+    RefreshWorker --> Metrics
+    AbstractHandler --> Metrics
+    CachedCustomerRepository --> Metrics
     Metrics --> Emitter
 ```
 
-Read requests continue to use the cache repository decorator. Write-side domain events invalidate affected tags and enqueue `RefreshCustomerCacheCommand` work for same-entity cache refresh. Refresh workers warm customer detail and email lookup cache entries through the inner repository without blocking business writes.
+## New Source Tree
 
-## Planned Source Tree
-
-The implementation PR should add the following source files and edit the listed existing feature files.
+The implementation PR should add reusable shared classes first, then add Customer as the first adapter. The tree below shows new files and existing files that should be edited.
 
 ```text
 src/
+  Shared/
+    Application/
+      Command/
+        RefreshCacheCommand.php
+      CommandHandler/
+        AbstractCacheRefreshCommandHandler.php
+        RefreshCacheCommandHandler.php
+      DTO/
+        CacheRefreshPolicy.php
+        CacheRefreshResult.php
+        CacheRefreshTarget.php
+      EventSubscriber/
+        AbstractCacheInvalidationSubscriber.php
+      Factory/
+        AbstractCacheRefreshCommandFactory.php
+      Observability/
+        Metric/
+          CacheHitMetric.php
+          CacheMissMetric.php
+          CacheRefreshFailedMetric.php
+          CacheRefreshScheduledMetric.php
+          CacheRefreshStaleServedMetric.php
+          CacheRefreshSucceededMetric.php
+          ValueObject/
+            CacheRefreshMetricDimensions.php
+      Resolver/
+        CacheRefreshCommandHandlerResolverInterface.php
+        CacheRefreshPolicyResolverInterface.php
+        CacheRefreshTargetResolverInterface.php
+    Infrastructure/
+      Cache/
+        CacheKeyBuilder.php (existing, edit for generic context/family key helpers)
+      Collection/
+        CacheRefreshCommandHandlerCollection.php
+        CacheRefreshPolicyCollection.php
+        CacheRefreshTargetResolverCollection.php
+      Resolver/
+        CacheRefreshCommandHandlerResolver.php
+        CacheRefreshPolicyResolver.php
   Core/
     Customer/
       Application/
-        Command/
-          RefreshCustomerCacheCommand.php
         CommandHandler/
-          RefreshCustomerCacheCommandHandler.php
-        DTO/
-          CustomerCachePolicy.php
+          CustomerCacheRefreshCommandHandler.php
         EventSubscriber/
           CustomerCreatedCacheInvalidationSubscriber.php (edit)
           CustomerDeletedCacheInvalidationSubscriber.php (edit)
           CustomerUpdatedCacheInvalidationSubscriber.php (edit)
         Factory/
-          CustomerCachePolicyFactory.php
           CustomerCacheRefreshCommandFactory.php
-        Metric/
-          CustomerCacheHitMetric.php
-          CustomerCacheMissMetric.php
-          CustomerCacheRefreshFailedMetric.php
-          CustomerCacheRefreshScheduledMetric.php
-          CustomerCacheRefreshSucceededMetric.php
-          CustomerCacheStaleServedMetric.php
-          ValueObject/
-            CustomerCacheMetricDimensions.php
       Infrastructure/
         Collection/
           CustomerCachePolicyCollection.php
@@ -124,43 +207,55 @@ src/
           CustomerCachePolicyResolver.php
           CustomerCacheRefreshTargetResolver.php
           CustomerCacheTagResolver.php (existing)
-  Shared/
-    Infrastructure/
-      Cache/
-        CacheKeyBuilder.php (existing, edit only for generic key helpers)
 ```
 
-This layout matches current source and deptrac boundaries:
-
-- `Application/Command`, `Application/CommandHandler`, `Application/DTO`, `Application/EventSubscriber`, `Application/Factory`, and `Application/Metric` are already collected as Application.
-- `Infrastructure/Collection`, `Infrastructure/Repository`, and `Infrastructure/Resolver` are already collected as Infrastructure.
-- `Shared/Infrastructure/Cache` already exists for shared cache utilities.
-- No new Customer `Infrastructure/Cache` directory is needed because cache behavior is part of the existing Customer repository, collection, resolver, and subscriber feature surface.
-
-Planned test files:
+Planned test tree:
 
 ```text
 tests/
   Unit/
-    Customer/
+    Shared/
       Application/
         Command/
-          RefreshCustomerCacheCommandTest.php
+          RefreshCacheCommandTest.php
         CommandHandler/
-          RefreshCustomerCacheCommandHandlerTest.php
+          AbstractCacheRefreshCommandHandlerTest.php
+          RefreshCacheCommandHandlerTest.php
         DTO/
-          CustomerCachePolicyTest.php
+          CacheRefreshPolicyTest.php
+          CacheRefreshResultTest.php
+          CacheRefreshTargetTest.php
+        EventSubscriber/
+          AbstractCacheInvalidationSubscriberTest.php
+        Factory/
+          AbstractCacheRefreshCommandFactoryTest.php
+        Observability/
+          Metric/
+            CacheRefreshMetricTest.php
+            ValueObject/
+              CacheRefreshMetricDimensionsTest.php
+        Resolver/
+          CacheRefreshCommandHandlerResolverInterfaceTest.php
+          CacheRefreshPolicyResolverInterfaceTest.php
+          CacheRefreshTargetResolverInterfaceTest.php
+      Infrastructure/
+        Collection/
+          CacheRefreshCommandHandlerCollectionTest.php
+          CacheRefreshPolicyCollectionTest.php
+          CacheRefreshTargetResolverCollectionTest.php
+        Resolver/
+          CacheRefreshCommandHandlerResolverTest.php
+          CacheRefreshPolicyResolverTest.php
+    Customer/
+      Application/
+        CommandHandler/
+          CustomerCacheRefreshCommandHandlerTest.php
         EventSubscriber/
           CustomerCreatedCacheInvalidationSubscriberTest.php
           CustomerDeletedCacheInvalidationSubscriberTest.php
           CustomerUpdatedCacheInvalidationSubscriberTest.php
         Factory/
-          CustomerCachePolicyFactoryTest.php
           CustomerCacheRefreshCommandFactoryTest.php
-        Metric/
-          CustomerCacheMetricTest.php
-          ValueObject/
-            CustomerCacheMetricDimensionsTest.php
       Infrastructure/
         Collection/
           CustomerCachePolicyCollectionTest.php
@@ -176,7 +271,7 @@ tests/
           AsyncCustomerCacheRefreshTest.php
 ```
 
-Configuration and documentation expected to change:
+Configuration and documentation expected to change in the later implementation PR:
 
 ```text
 config/
@@ -196,44 +291,79 @@ docs/
   performance.md
 ```
 
-## Proposed Components
+## Shared Components
 
-### Cache Policy Model
+### Generic Refresh Command
 
-Add cache policy classes through existing class-type directories:
+`RefreshCacheCommand` is the single queue payload for all bounded contexts. It should carry scalar, serialization-stable data only:
 
-- `CustomerCachePolicy` in `Application/DTO`
-- `CustomerCachePolicyFactory` in `Application/Factory`
-- `CustomerCachePolicyCollection` in `Infrastructure/Collection`
-- `CustomerCachePolicyResolver` in `Infrastructure/Resolver`
+- context name, such as `customer`
+- cache family, such as `detail` or `lookup`
+- target identifiers as a string map
+- triggering domain event name and event ID
+- occurred-at timestamp
+- refresh strategy
+- attempt metadata where Messenger retry handling needs it
 
-Use services.yaml arguments for TTLs and jitter so defaults are configurable without editing repository code. Avoid separate enum classes in the first implementation unless the implementation already has an existing enum directory pattern to reuse.
+The command must not contain Customer-specific fields such as `customerEmail`. Customer-specific meaning belongs in `CustomerCacheRefreshCommandFactory` and `CustomerCacheRefreshTargetResolver`.
 
-### Cache Refresh Command Path
+### Abstract Subscriber Contract
 
-Add a dedicated command model instead of a separate message model:
+`AbstractCacheInvalidationSubscriber` should handle the common sequence:
 
-- `RefreshCustomerCacheCommand` in `Application/Command`
-- `RefreshCustomerCacheCommandHandler` in `Application/CommandHandler`
-- `CustomerCacheRefreshCommandFactory` in `Application/Factory`
-- `CustomerCacheRefreshTargetResolver` in `Infrastructure/Resolver`
+1. Resolve affected cache targets from the domain event.
+2. Invalidate tags immediately.
+3. Create one or more `RefreshCacheCommand` instances.
+4. Dispatch refresh commands best-effort.
+5. Emit scheduled or failed metrics without breaking domain-event processing.
 
-The command should carry scalar payload only, such as family name, customer ID, email, and event metadata, so it remains stable across Messenger serialization. Event subscribers create refresh commands after invalidation and dispatch them best-effort through Messenger or the configured command path. The handler warms same-entity entries from persisted state, such as customer detail by ID and lookup by email. For delete events, it should avoid warming deleted entities and may only preserve invalidation behavior.
+Concrete subscribers should only map a domain event to context-specific tags and targets.
 
-### Repository Decorator Changes
+### Shared Worker Contract
 
-Update `CachedCustomerRepository` to inject:
+`RefreshCacheCommandHandler` is the single Messenger worker entrypoint for the `cache-refresh` queue. It should:
 
-- detail cache pool
-- lookup cache pool
-- policy resolver
-- metrics emitter or cache metrics service
+1. Resolve a registered context command handler by context and family.
+2. Delegate refresh execution to that context handler.
+3. Emit common success or failure metrics.
+4. Let Messenger route unrecoverable job failures to `failed-cache-refresh` according to configured retry strategy.
 
-Use the policy resolver for TTL, tags, and cache key metadata. Preserve existing `findFresh()` bypass behavior for write paths.
+`AbstractCacheRefreshCommandHandler` should hold the reusable refresh template for context handlers:
 
-### Messenger Configuration
+1. Resolve the cache policy.
+2. Resolve the concrete target.
+3. Build cache keys through `CacheKeyBuilder`.
+4. Refresh the cache through a context repository callback.
+5. Return a `CacheRefreshResult`.
 
-Add:
+Concrete handlers, such as `CustomerCacheRefreshCommandHandler`, should only provide context-specific target loading, such as customer detail by ID or customer lookup by email.
+
+### Policy and Target Resolution
+
+`CacheRefreshPolicy` belongs in `Shared/Application/DTO` because it is data passed across application orchestration. It should contain:
+
+- context
+- family
+- key namespace
+- tags
+- soft TTL
+- hard TTL
+- jitter
+- consistency class
+- refresh strategy
+
+`CacheRefreshPolicyCollection` belongs in `Shared/Infrastructure/Collection` as the generic iterable policy holder. `CustomerCachePolicyCollection` may compose or configure customer policies in the Customer context, but policy lookup should be performed through the shared resolver interface.
+
+`CacheRefreshTarget` belongs in `Shared/Application/DTO`. It should describe what must be refreshed without depending on Customer classes.
+
+## Queue and Worker Model
+
+Use two worker paths:
+
+- Existing `domain-events` queue: reads any domain event through `DomainEventMessageHandler`.
+- New `cache-refresh` queue: reads the generic `RefreshCacheCommand` through `RefreshCacheCommandHandler`.
+
+The implementation should add a single shared cache-refresh transport:
 
 - `CACHE_REFRESH_QUEUE_NAME`
 - `FAILED_CACHE_REFRESH_QUEUE_NAME`
@@ -241,41 +371,61 @@ Add:
 - `FAILED_CACHE_REFRESH_TRANSPORT_DSN`
 - `cache-refresh` transport
 - `failed-cache-refresh` transport
-- routing for `RefreshCustomerCacheCommand`
 
-In `when@test`, route cache refresh to an in-memory transport.
+Do not create per-domain cache-refresh queues in the first implementation. A single queue keeps worker operations reusable. If future throughput requires separate queues, that should be an operations-driven follow-up with metrics evidence.
 
-### Observability
+## Customer Adapter
 
-Add typed metrics under `src/Core/Customer/Application/Metric`:
+Customer should be the first adapter for the shared design:
 
-- `CustomerCacheRefreshScheduledMetric`
-- `CustomerCacheRefreshSucceededMetric`
-- `CustomerCacheRefreshFailedMetric`
-- `CustomerCacheHitMetric`
-- `CustomerCacheMissMetric`
-- `CustomerCacheStaleServedMetric`
+- Customer create/update/delete subscribers extend or delegate to `AbstractCacheInvalidationSubscriber`.
+- `CustomerCacheRefreshCommandFactory` creates generic `RefreshCacheCommand` instances from Customer events.
+- `CustomerCacheRefreshTargetResolver` maps target DTOs to Customer repository lookup inputs.
+- `CustomerCachePolicyCollection` declares Customer detail, lookup, collection, reference, and negative lookup policies.
+- `CustomerCacheRefreshCommandHandler` extends or composes `AbstractCacheRefreshCommandHandler` and registers for `customer` context families.
+- `CachedCustomerRepository` consumes the shared policy resolver and key builder instead of method-local TTL literals.
 
-Place metric dimension value objects under `Application/Metric/ValueObject` so metric classes and value objects do not share one directory.
+The first implementation should refresh currently cached same-entity families:
 
-### Failure Semantics
+- Customer detail by ID.
+- Customer lookup by email.
 
-- Repository cache failures fall back to the inner repository.
-- Subscriber dispatch failures log and emit a failure metric, then return.
-- Command handler failures log and emit a failure metric, then return so poison refresh jobs do not block business behavior.
-- Domain event subscribers remain resilient through the existing `DomainEventMessageHandler`.
+Collection and reference policies should be declared and immediately invalidated by tags, but arbitrary proactive collection materialization stays out of scope until the codebase has a stable query-shape abstraction.
+
+## Observability
+
+Metric classes should be shared because refresh lifecycle is not Customer-specific:
+
+- `CacheRefreshScheduledMetric`
+- `CacheRefreshSucceededMetric`
+- `CacheRefreshFailedMetric`
+- `CacheHitMetric`
+- `CacheMissMetric`
+- `CacheRefreshStaleServedMetric`
+
+Place them under `Shared/Application/Observability/Metric`. Use dimensions such as context, family, source event, result, and failure type. Context-specific metrics should only be added when a bounded context needs dimensions that the shared classes cannot represent.
+
+## Failure Semantics
+
+- Cache failures fall back to the inner repository where the current repository already does so.
+- Subscriber dispatch failures are logged and measured but do not break domain-event handling.
+- Worker refresh failures are logged and measured; retry and failed routing are controlled by Messenger.
+- Delete events invalidate and avoid warming deleted entities.
+- Domain remains free of Symfony, cache, Messenger, logging, and metrics dependencies.
 
 ## Implementation Sequence
 
-1. Add policy DTO, factory, collection, resolver, and tests.
-2. Split cache pools and update repository TTL usage.
-3. Add refresh command, command factory, command handler, target resolver, and Messenger routing.
-4. Update subscribers to invalidate plus dispatch refresh commands.
-5. Add metrics and tests.
-6. Add integration proof and docs.
-7. Run CI and cache performance evidence.
+1. Add shared DTOs, resolver interfaces, collections, abstract subscriber, abstract factory, generic refresh command, generic worker, abstract context handler, and shared metrics.
+2. Add the single `cache-refresh` and `failed-cache-refresh` Messenger transports.
+3. Add Customer adapter classes that extend or compose the shared abstractions.
+4. Update `CachedCustomerRepository` to use resolved policies and generic key helpers.
+5. Update Customer subscribers to invalidate plus schedule refresh work through the shared subscriber path.
+6. Add unit and integration tests for shared orchestration and the Customer adapter.
+7. Update docs and run cache performance evidence where runtime services allow.
 
 ## Architectural Tradeoffs
 
-- The first PR should not attempt generic API Platform collection caching. That requires a provider-level design and may be a separate architecture change.
-- Reference-data policies can be declared before reference-data domain events exist. Full refresh triggering for type/status mutations should be follow-up work unless events are added in this PR.
+- This design keeps reusable orchestration in `Shared` and leaves domain-specific mapping in bounded contexts.
+- It uses the existing CQRS command/handler names instead of inventing `Request`, `Message`, `MessageHandler`, `Scheduler`, or `Worker` directories.
+- It uses `Policy` as a DTO class name, not as a new directory type.
+- It avoids `ReadModel` because the current project read paths are repository and resolver based, and issue #176 is about refreshing endpoint cache entries rather than introducing a separate projection model.

--- a/specs/issue-176-async-cache-refresh/architecture.md
+++ b/specs/issue-176-async-cache-refresh/architecture.md
@@ -46,8 +46,8 @@ flowchart LR
     subgraph SharedRefresh["Shared cache-refresh foundation"]
         AbstractSubscriber["AbstractCacheInvalidationSubscriber"]
         AbstractFactory["AbstractCacheRefreshCommandFactory"]
-        RefreshCommand["RefreshCacheCommand\nscalar reusable payload"]
-        RefreshWorker["RefreshCacheCommandHandler\nsingle shared worker"]
+        RefreshCommand["CacheRefreshCommand\nscalar reusable payload"]
+        RefreshWorker["CacheRefreshCommandHandler\nsingle shared worker"]
         AbstractHandler["AbstractCacheRefreshCommandHandler"]
         PolicyDto["CacheRefreshPolicy DTO"]
         TargetDto["CacheRefreshTarget DTO"]
@@ -150,10 +150,10 @@ src/
   Shared/
     Application/
       Command/
-        RefreshCacheCommand.php
+        CacheRefreshCommand.php
       CommandHandler/
         AbstractCacheRefreshCommandHandler.php
-        RefreshCacheCommandHandler.php
+        CacheRefreshCommandHandler.php
       DTO/
         CacheRefreshPolicy.php
         CacheRefreshResult.php
@@ -217,10 +217,10 @@ tests/
     Shared/
       Application/
         Command/
-          RefreshCacheCommandTest.php
+          CacheRefreshCommandTest.php
         CommandHandler/
           AbstractCacheRefreshCommandHandlerTest.php
-          RefreshCacheCommandHandlerTest.php
+          CacheRefreshCommandHandlerTest.php
         DTO/
           CacheRefreshPolicyTest.php
           CacheRefreshResultTest.php
@@ -295,7 +295,7 @@ docs/
 
 ### Generic Refresh Command
 
-`RefreshCacheCommand` is the single queue payload for all bounded contexts. It should carry scalar, serialization-stable data only:
+`CacheRefreshCommand` is the single queue payload for all bounded contexts. It should carry scalar, serialization-stable data only:
 
 - context name, such as `customer`
 - cache family, such as `detail` or `lookup`
@@ -313,7 +313,7 @@ The command must not contain Customer-specific fields such as `customerEmail`. C
 
 1. Resolve affected cache targets from the domain event.
 2. Invalidate tags immediately.
-3. Create one or more `RefreshCacheCommand` instances.
+3. Create one or more `CacheRefreshCommand` instances.
 4. Dispatch refresh commands best-effort.
 5. Emit scheduled or failed metrics without breaking domain-event processing.
 
@@ -321,7 +321,7 @@ Concrete subscribers should only map a domain event to context-specific tags and
 
 ### Shared Worker Contract
 
-`RefreshCacheCommandHandler` is the single Messenger worker entrypoint for the `cache-refresh` queue. It should:
+`CacheRefreshCommandHandler` is the single Messenger worker entrypoint for the `cache-refresh` queue. It should:
 
 1. Resolve a registered context command handler by context and family.
 2. Delegate refresh execution to that context handler.
@@ -361,7 +361,7 @@ Concrete handlers, such as `CustomerCacheRefreshCommandHandler`, should only pro
 Use two worker paths:
 
 - Existing `domain-events` queue: reads any domain event through `DomainEventMessageHandler`.
-- New `cache-refresh` queue: reads the generic `RefreshCacheCommand` through `RefreshCacheCommandHandler`.
+- New `cache-refresh` queue: reads the generic `CacheRefreshCommand` through `CacheRefreshCommandHandler`.
 
 The implementation should add a single shared cache-refresh transport:
 
@@ -379,7 +379,7 @@ Do not create per-domain cache-refresh queues in the first implementation. A sin
 Customer should be the first adapter for the shared design:
 
 - Customer create/update/delete subscribers extend or delegate to `AbstractCacheInvalidationSubscriber`.
-- `CustomerCacheRefreshCommandFactory` creates generic `RefreshCacheCommand` instances from Customer events.
+- `CustomerCacheRefreshCommandFactory` creates generic `CacheRefreshCommand` instances from Customer events.
 - `CustomerCacheRefreshTargetResolver` maps target DTOs to Customer repository lookup inputs.
 - `CustomerCachePolicyCollection` declares Customer detail, lookup, collection, reference, and negative lookup policies.
 - `CustomerCacheRefreshCommandHandler` extends or composes `AbstractCacheRefreshCommandHandler` and registers for `customer` context families.

--- a/specs/issue-176-async-cache-refresh/architecture.md
+++ b/specs/issue-176-async-cache-refresh/architecture.md
@@ -2,7 +2,9 @@
 
 ## Current Architecture Fit
 
-Issue #176 should introduce a reusable cache-refresh foundation, not a Customer-only worker design. Customer is the first adopter because it already has cached repository reads and domain-event cache invalidation subscribers, but the refresh command, queue, worker, metrics, and abstract orchestration must be reusable by future bounded contexts.
+Issue #176 should introduce a reusable cache-refresh foundation, not a Customer-only worker design. Customer is the first adopter because it already has cached repository reads and cache invalidation paths, but the invalidation listener, refresh command, queue, worker, metrics, and abstract orchestration must be reusable by future bounded contexts.
+
+Automatic CRUD invalidation should be handled close to persistence through a shared Doctrine MongoDB ODM listener. Domain events remain useful for cross-context reactions and async refresh scheduling, but the current Customer events do not carry complete cacheable entity snapshots. They can safely identify affected cache entries; they should not be the only source for rebuilding cached values unless future events add complete, versioned, serialization-stable payloads.
 
 The current repository already has the right primitives:
 
@@ -13,6 +15,8 @@ The current repository already has the right primitives:
 - Shared metrics already live in `Shared/Application/Observability/Metric`.
 - Shared cache utilities already live in `Shared/Infrastructure/Cache`.
 - Context-specific cache behavior already appears as repository decorators, collections, resolvers, factories, and event subscribers.
+- Repository writes commonly flow through `BaseRepository::save()` and `BaseRepository::delete()`, while some infrastructure repositories use custom delete methods. An ODM flush listener can cover these persistence paths more consistently than per-entity cache repositories.
+- ODM change sets can expose old and new indexed values, such as previous and current Customer email, which are needed for correct tag invalidation.
 
 The implementation should add shared abstractions and thin context adapters. It should not add Customer-only queue contracts that future domains would need to copy.
 
@@ -24,10 +28,12 @@ This plan follows the repository rule: one directory contains one class type.
 - Put reusable refresh command handlers and abstract handler bases in `src/Shared/Application/CommandHandler`.
 - Put reusable DTOs, resolver interfaces, event-subscriber bases, factories, and metrics in their matching class-type directories.
 - Put reusable metrics under `src/Shared/Application/Observability/Metric`, matching the existing shared observability structure.
-- Put reusable infrastructure collaborators in existing or deptrac-collected class-type directories such as `src/Shared/Infrastructure/{Cache,Collection,Resolver}`.
+- Put reusable infrastructure collaborators in existing or deptrac-collected class-type directories such as `src/Shared/Infrastructure/{Cache,Collection,EventListener,Resolver}`.
 - Put bounded-context adapters in existing context directories such as `src/Core/Customer/Application/{CommandHandler,EventSubscriber,Factory}` and `src/Core/Customer/Infrastructure/{Collection,Repository,Resolver}`.
 - Do not introduce new context directories named `Cache`, `ReadModel`, `Policy`, `Registry`, `Scheduler`, `Message`, or `MessageHandler`.
 - Do not create a Customer `Infrastructure/Cache` directory. Cache refresh is part of the existing repository, collection, resolver, subscriber, factory, command, and handler surface.
+- Do not add cache invalidation methods to Domain repository interfaces. Cache invalidation is an infrastructure/application concern and must not leak into Domain contracts.
+- Put automatic CRUD invalidation mapping in resolver and collection classes keyed by document class, operation, and changed fields.
 
 ## Architecture Diagram
 
@@ -37,16 +43,28 @@ flowchart LR
         DomainEvent["DomainEvent\nCustomerCreatedEvent\nFutureContextEvent"]
     end
 
+    subgraph WriteSide["Any bounded-context write side"]
+        WriteApi["Write API\ncommand handlers"]
+        OdmFlush["Doctrine MongoDB ODM flush"]
+    end
+
     subgraph DomainEventWorker["Shared async domain-event path"]
         EventEnvelope["DomainEventEnvelope"]
         EventQueue["domain-events SQS transport\nLocalStack locally"]
         EventWorker["DomainEventMessageHandler\nreads any domain event"]
     end
 
+    subgraph SharedInvalidation["Shared automatic CRUD invalidation"]
+        InvalidationListener["CacheInvalidationDoctrineEventListener"]
+        RuleCollection["CacheInvalidationRuleCollection"]
+        TagResolver["CacheInvalidationTagResolver"]
+        TagSetDto["CacheInvalidationTagSet DTO"]
+    end
+
     subgraph SharedRefresh["Shared cache-refresh foundation"]
         AbstractSubscriber["AbstractCacheInvalidationSubscriber"]
         AbstractFactory["AbstractCacheRefreshCommandFactory"]
-        RefreshCommand["CacheRefreshCommand\nscalar reusable payload"]
+        RefreshCommand["CacheRefreshCommand\nrepository_refresh | event_snapshot | invalidate_only"]
         RefreshWorker["CacheRefreshCommandHandler\nsingle shared worker"]
         AbstractHandler["AbstractCacheRefreshCommandHandler"]
         PolicyDto["CacheRefreshPolicy DTO"]
@@ -64,6 +82,8 @@ flowchart LR
         CustomerFactory["CustomerCacheRefreshCommandFactory"]
         CustomerHandler["CustomerCacheRefreshCommandHandler\nregistered adapter"]
         CustomerTargetResolver["CustomerCacheRefreshTargetResolver"]
+        CustomerInvalidationRules["CustomerCacheInvalidationRuleCollection"]
+        CustomerInvalidationResolver["CustomerCacheInvalidationTagResolver"]
         CustomerPolicyCollection["CustomerCachePolicyCollection"]
         CachedCustomerRepository["CachedCustomerRepository"]
         CustomerRepository["MongoCustomerRepository"]
@@ -90,7 +110,19 @@ flowchart LR
         Emitter["BusinessMetricsEmitterInterface"]
     end
 
-    WriteApi["Any write API\ncommand handlers"] --> DomainEvent
+    WriteApi --> DomainEvent
+    WriteApi --> OdmFlush
+    OdmFlush --> InvalidationListener
+    InvalidationListener --> RuleCollection
+    RuleCollection --> CustomerInvalidationRules
+    CustomerInvalidationRules --> CustomerInvalidationResolver
+    InvalidationListener --> TagResolver
+    CustomerInvalidationResolver --> TagResolver
+    TagResolver --> TagSetDto
+    TagSetDto --> CachePools
+    InvalidationListener --> RefreshCommand
+    InvalidationListener --> Metrics
+
     DomainEvent --> EventEnvelope
     EventEnvelope --> EventQueue
     EventQueue --> EventWorker
@@ -155,6 +187,8 @@ src/
         AbstractCacheRefreshCommandHandler.php
         CacheRefreshCommandHandler.php
       DTO/
+        CacheInvalidationRule.php
+        CacheInvalidationTagSet.php
         CacheRefreshPolicy.php
         CacheRefreshResult.php
         CacheRefreshTarget.php
@@ -180,10 +214,14 @@ src/
       Cache/
         CacheKeyBuilder.php (existing, edit for generic context/family key helpers)
       Collection/
+        CacheInvalidationRuleCollection.php
         CacheRefreshCommandHandlerCollection.php
         CacheRefreshPolicyCollection.php
         CacheRefreshTargetResolverCollection.php
+      EventListener/
+        CacheInvalidationDoctrineEventListener.php
       Resolver/
+        CacheInvalidationTagResolver.php
         CacheRefreshCommandHandlerResolver.php
         CacheRefreshPolicyResolver.php
   Core/
@@ -199,11 +237,13 @@ src/
           CustomerCacheRefreshCommandFactory.php
       Infrastructure/
         Collection/
+          CustomerCacheInvalidationRuleCollection.php
           CustomerCachePolicyCollection.php
           CustomerCacheTagCollection.php (existing)
         Repository/
           CachedCustomerRepository.php (edit)
         Resolver/
+          CustomerCacheInvalidationTagResolver.php
           CustomerCachePolicyResolver.php
           CustomerCacheRefreshTargetResolver.php
           CustomerCacheTagResolver.php (existing)
@@ -222,6 +262,8 @@ tests/
           AbstractCacheRefreshCommandHandlerTest.php
           CacheRefreshCommandHandlerTest.php
         DTO/
+          CacheInvalidationRuleTest.php
+          CacheInvalidationTagSetTest.php
           CacheRefreshPolicyTest.php
           CacheRefreshResultTest.php
           CacheRefreshTargetTest.php
@@ -240,10 +282,14 @@ tests/
           CacheRefreshTargetResolverInterfaceTest.php
       Infrastructure/
         Collection/
+          CacheInvalidationRuleCollectionTest.php
           CacheRefreshCommandHandlerCollectionTest.php
           CacheRefreshPolicyCollectionTest.php
           CacheRefreshTargetResolverCollectionTest.php
+        EventListener/
+          CacheInvalidationDoctrineEventListenerTest.php
         Resolver/
+          CacheInvalidationTagResolverTest.php
           CacheRefreshCommandHandlerResolverTest.php
           CacheRefreshPolicyResolverTest.php
     Customer/
@@ -258,10 +304,13 @@ tests/
           CustomerCacheRefreshCommandFactoryTest.php
       Infrastructure/
         Collection/
+          CustomerCacheInvalidationRuleCollectionTest.php
           CustomerCachePolicyCollectionTest.php
         Repository/
+          AutomaticCustomerCacheInvalidationTest.php
           CachedCustomerRepositoryPolicyTest.php
         Resolver/
+          CustomerCacheInvalidationTagResolverTest.php
           CustomerCachePolicyResolverTest.php
           CustomerCacheRefreshTargetResolverTest.php
   Integration/
@@ -293,6 +342,23 @@ docs/
 
 ## Shared Components
 
+### Automatic CRUD Invalidation
+
+`CacheInvalidationDoctrineEventListener` should be the generic write-side invalidation point for CRUD operations. It belongs in `Shared/Infrastructure/EventListener` because it depends on Doctrine MongoDB ODM flush lifecycle details.
+
+The listener should:
+
+1. Inspect scheduled insertions, updates, and deletions during flush.
+2. Read document class, operation type, identifier, and change-set values.
+3. Resolve cache tags through a context-provided rule collection and tag resolver.
+4. Collect invalidation work during flush and invalidate tags only after a successful flush.
+5. Optionally enqueue `CacheRefreshCommand` jobs for policies whose refresh source is `repository_refresh`.
+6. Emit invalidation and scheduling metrics without failing completed business writes.
+
+This is preferred over a per-entity cache repository or a Domain repository interface change because it covers `BaseRepository::save()`, `BaseRepository::delete()`, and custom infrastructure delete methods that still flush through ODM. A repository base-class hook can be a fallback only for writes that bypass ODM lifecycle events.
+
+Context-specific mapping remains thin. For Customer, `CustomerCacheInvalidationRuleCollection` and `CustomerCacheInvalidationTagResolver` should map Customer document changes to existing customer ID, email, and collection tags. Update operations must invalidate both previous and current email tags when email changes.
+
 ### Generic Refresh Command
 
 `CacheRefreshCommand` is the single queue payload for all bounded contexts. It should carry scalar, serialization-stable data only:
@@ -303,13 +369,18 @@ docs/
 - triggering domain event name and event ID
 - occurred-at timestamp
 - refresh strategy
+- refresh source, such as `repository_refresh`, `event_snapshot`, or `invalidate_only`
 - attempt metadata where Messenger retry handling needs it
 
 The command must not contain Customer-specific fields such as `customerEmail`. Customer-specific meaning belongs in `CustomerCacheRefreshCommandFactory` and `CustomerCacheRefreshTargetResolver`.
 
+The default refresh source for issue #176 is `repository_refresh`: the worker reloads current persisted state through the context adapter and writes the cache entry. `event_snapshot` is a future option only for events that carry a complete, versioned, serialization-stable cache payload and have stale-overwrite guards. Deletes should use `invalidate_only` or tombstone-aware handling rather than warming a removed entity.
+
 ### Abstract Subscriber Contract
 
-`AbstractCacheInvalidationSubscriber` should handle the common sequence:
+`AbstractCacheInvalidationSubscriber` should handle domain-event-driven invalidation and refresh scheduling for events that need more than CRUD write detection. It is not the only invalidation path; `CacheInvalidationDoctrineEventListener` owns automatic CRUD invalidation.
+
+The subscriber should handle the common sequence:
 
 1. Resolve affected cache targets from the domain event.
 2. Invalidate tags immediately.
@@ -317,7 +388,7 @@ The command must not contain Customer-specific fields such as `customerEmail`. C
 4. Dispatch refresh commands best-effort.
 5. Emit scheduled or failed metrics without breaking domain-event processing.
 
-Concrete subscribers should only map a domain event to context-specific tags and targets.
+Concrete subscribers should only map a domain event to context-specific tags and targets. They should not contain cache key construction, queue routing, or worker logic.
 
 ### Shared Worker Contract
 
@@ -333,7 +404,10 @@ Concrete subscribers should only map a domain event to context-specific tags and
 1. Resolve the cache policy.
 2. Resolve the concrete target.
 3. Build cache keys through `CacheKeyBuilder`.
-4. Refresh the cache through a context repository callback.
+4. Execute the configured refresh source:
+   - `repository_refresh`: load current persisted state through a context repository callback and write the cache entry.
+   - `event_snapshot`: materialize the cache entry from a complete, versioned event payload when a future event supports it.
+   - `invalidate_only`: leave the cache empty after invalidation, typically for deletes or unsupported query families.
 5. Return a `CacheRefreshResult`.
 
 Concrete handlers, such as `CustomerCacheRefreshCommandHandler`, should only provide context-specific target loading, such as customer detail by ID or customer lookup by email.
@@ -351,6 +425,7 @@ Concrete handlers, such as `CustomerCacheRefreshCommandHandler`, should only pro
 - jitter
 - consistency class
 - refresh strategy
+- refresh source
 
 `CacheRefreshPolicyCollection` belongs in `Shared/Infrastructure/Collection` as the generic iterable policy holder. `CustomerCachePolicyCollection` may compose or configure customer policies in the Customer context, but policy lookup should be performed through the shared resolver interface.
 
@@ -378,9 +453,12 @@ Do not create per-domain cache-refresh queues in the first implementation. A sin
 
 Customer should be the first adapter for the shared design:
 
-- Customer create/update/delete subscribers extend or delegate to `AbstractCacheInvalidationSubscriber`.
+- Customer CRUD invalidation uses the shared ODM listener plus Customer invalidation rules/resolvers.
+- Customer create/update/delete subscribers can remain as domain-event adapters for scheduling or cross-context behavior, but they should not be required for same-aggregate CRUD cache tag invalidation.
 - `CustomerCacheRefreshCommandFactory` creates generic `CacheRefreshCommand` instances from Customer events.
 - `CustomerCacheRefreshTargetResolver` maps target DTOs to Customer repository lookup inputs.
+- `CustomerCacheInvalidationRuleCollection` maps Customer document operations and changed fields to invalidation rules.
+- `CustomerCacheInvalidationTagResolver` derives concrete ID, email, collection, and old-email tags from ODM change-set data.
 - `CustomerCachePolicyCollection` declares Customer detail, lookup, collection, reference, and negative lookup policies.
 - `CustomerCacheRefreshCommandHandler` extends or composes `AbstractCacheRefreshCommandHandler` and registers for `customer` context families.
 - `CachedCustomerRepository` consumes the shared policy resolver and key builder instead of method-local TTL literals.
@@ -391,6 +469,8 @@ The first implementation should refresh currently cached same-entity families:
 - Customer lookup by email.
 
 Collection and reference policies should be declared and immediately invalidated by tags, but arbitrary proactive collection materialization stays out of scope until the codebase has a stable query-shape abstraction.
+
+The first Customer implementation should use `repository_refresh` for detail and email lookup. Current Customer domain events carry IDs and emails, not the complete Customer cache payload, so event-only refresh would risk writing incomplete or stale values.
 
 ## Observability
 
@@ -408,6 +488,8 @@ Place them under `Shared/Application/Observability/Metric`. Use dimensions such 
 ## Failure Semantics
 
 - Cache failures fall back to the inner repository where the current repository already does so.
+- ODM listener collection happens during flush, but cache invalidation runs only after a successful flush so failed writes do not evict good cache entries.
+- ODM listener invalidation or scheduling failures are logged and measured after the write succeeds; they do not roll back a completed business write.
 - Subscriber dispatch failures are logged and measured but do not break domain-event handling.
 - Worker refresh failures are logged and measured; retry and failed routing are controlled by Messenger.
 - Delete events invalidate and avoid warming deleted entities.
@@ -415,13 +497,14 @@ Place them under `Shared/Application/Observability/Metric`. Use dimensions such 
 
 ## Implementation Sequence
 
-1. Add shared DTOs, resolver interfaces, collections, abstract subscriber, abstract factory, generic refresh command, generic worker, abstract context handler, and shared metrics.
-2. Add the single `cache-refresh` and `failed-cache-refresh` Messenger transports.
-3. Add Customer adapter classes that extend or compose the shared abstractions.
-4. Update `CachedCustomerRepository` to use resolved policies and generic key helpers.
-5. Update Customer subscribers to invalidate plus schedule refresh work through the shared subscriber path.
-6. Add unit and integration tests for shared orchestration and the Customer adapter.
-7. Update docs and run cache performance evidence where runtime services allow.
+1. Add shared DTOs, resolver interfaces, collections, abstract subscriber, abstract factory, generic refresh command, generic worker, abstract context handler, ODM invalidation listener, and shared metrics.
+2. Add generic invalidation rule/tag resolution and Customer invalidation rules for CRUD create/update/delete change sets.
+3. Add the single `cache-refresh` and `failed-cache-refresh` Messenger transports.
+4. Add Customer adapter classes that extend or compose the shared abstractions.
+5. Update `CachedCustomerRepository` to use resolved policies and generic key helpers.
+6. Update Customer subscribers only for domain-event scheduling needs that are not already handled by automatic CRUD invalidation.
+7. Add unit and integration tests for shared orchestration, automatic CRUD invalidation, and the Customer adapter.
+8. Update docs and run cache performance evidence where runtime services allow.
 
 ## Architectural Tradeoffs
 
@@ -429,3 +512,5 @@ Place them under `Shared/Application/Observability/Metric`. Use dimensions such 
 - It uses the existing CQRS command/handler names instead of inventing `Request`, `Message`, `MessageHandler`, `Scheduler`, or `Worker` directories.
 - It uses `Policy` as a DTO class name, not as a new directory type.
 - It avoids `ReadModel` because the current project read paths are repository and resolver based, and issue #176 is about refreshing endpoint cache entries rather than introducing a separate projection model.
+- It chooses an ODM flush listener for automatic CRUD invalidation because it can observe all flushed document changes and old/new values. An abstract repository invalidation base is narrower and can miss custom infrastructure methods or direct `DocumentManager` writes.
+- It keeps repository interfaces cache-free. Cache invalidation mapping is expressed through infrastructure resolver and collection classes, not Domain contracts.

--- a/specs/issue-176-async-cache-refresh/architecture.md
+++ b/specs/issue-176-async-cache-refresh/architecture.md
@@ -63,6 +63,8 @@ flowchart LR
     RefreshCommand --> RefreshHandler
     RefreshHandler --> PolicyResolver
     PolicyResolver --> PolicyCollection
+    PolicyResolver --> PolicyDto
+    RefreshHandler --> PolicyDto
     RefreshHandler --> InnerRepo
     RefreshHandler --> KeyBuilder
     RefreshHandler --> CachePools

--- a/specs/issue-176-async-cache-refresh/architecture.md
+++ b/specs/issue-176-async-cache-refresh/architecture.md
@@ -4,7 +4,7 @@
 
 Issue #176 should introduce a reusable cache-refresh foundation, not a Customer-only worker design. Customer is the first adopter because it already has cached repository reads and cache invalidation paths, but the invalidation listener, refresh command, queue, worker, metrics, and abstract orchestration must be reusable by future bounded contexts.
 
-Automatic CRUD invalidation should be handled close to persistence through a shared Doctrine MongoDB ODM listener. Domain events remain useful for cross-context reactions and async refresh scheduling, but the current Customer events do not carry complete cacheable entity snapshots. They can safely identify affected cache entries; they should not be the only source for rebuilding cached values unless future events add complete, versioned, serialization-stable payloads.
+Automatic cache invalidation should be layered so the system clears cache whenever a reliable signal exists. Managed document changes are handled close to persistence through a shared Doctrine MongoDB ODM listener. Exposed domain events also invalidate and can schedule refresh work through shared subscribers. Custom repository methods that bypass ODM change sets must call the same shared invalidation command after a successful write. Current Customer events do not carry complete cacheable entity snapshots, so they can identify affected cache entries but should not be the only source for rebuilding cached values unless future events add complete, versioned, serialization-stable payloads.
 
 The current repository already has the right primitives:
 
@@ -15,8 +15,10 @@ The current repository already has the right primitives:
 - Shared metrics already live in `Shared/Application/Observability/Metric`.
 - Shared cache utilities already live in `Shared/Infrastructure/Cache`.
 - Context-specific cache behavior already appears as repository decorators, collections, resolvers, factories, and event subscribers.
-- Repository writes commonly flow through `BaseRepository::save()` and `BaseRepository::delete()`, while some infrastructure repositories use custom delete methods. An ODM flush listener can cover these persistence paths more consistently than per-entity cache repositories.
+- Repository writes commonly flow through `BaseRepository::save()` and `BaseRepository::delete()`, while some infrastructure repositories use custom delete methods such as `deleteByEmail`, `deleteById`, and `deleteByValue`. The current custom methods still remove managed documents and flush through ODM, so the ODM listener should cover them.
 - ODM change sets can expose old and new indexed values, such as previous and current Customer email, which are needed for correct tag invalidation.
+- Domain event subscribers already give a second automatic invalidation signal when business code exposes events.
+- Future bulk writes or direct database operations may bypass ODM UnitOfWork change sets. Those custom repository methods need an explicit repository-level fallback that calls the shared invalidation command with the affected context, family, and identifiers after the write succeeds.
 
 The implementation should add shared abstractions and thin context adapters. It should not add Customer-only queue contracts that future domains would need to copy.
 
@@ -34,6 +36,7 @@ This plan follows the repository rule: one directory contains one class type.
 - Do not create a Customer `Infrastructure/Cache` directory. Cache refresh is part of the existing repository, collection, resolver, subscriber, factory, command, and handler surface.
 - Do not add cache invalidation methods to Domain repository interfaces. Cache invalidation is an infrastructure/application concern and must not leak into Domain contracts.
 - Put automatic CRUD invalidation mapping in resolver and collection classes keyed by document class, operation, and changed fields.
+- Put repository-level fallback calls inside existing `Infrastructure/Repository` classes only for custom write methods that cannot be observed by ODM lifecycle events. They should reuse the shared invalidation command/resolver surface and stay best effort.
 
 ## Architecture Diagram
 
@@ -54,7 +57,9 @@ flowchart LR
         EventWorker["DomainEventMessageHandler\nreads any domain event"]
     end
 
-    subgraph SharedInvalidation["Shared automatic CRUD invalidation"]
+    subgraph SharedInvalidation["Shared layered invalidation"]
+        InvalidationCommand["CacheInvalidationCommand\nidempotent tag clear request"]
+        InvalidationHandler["CacheInvalidationCommandHandler"]
         InvalidationListener["CacheInvalidationDoctrineEventListener"]
         RuleCollection["CacheInvalidationRuleCollection"]
         TagResolver["CacheInvalidationTagResolver"]
@@ -87,6 +92,7 @@ flowchart LR
         CustomerPolicyCollection["CustomerCachePolicyCollection"]
         CachedCustomerRepository["CachedCustomerRepository"]
         CustomerRepository["MongoCustomerRepository"]
+        CustomRepoFallback["Custom repository fallback\nonly when ODM cannot observe"]
     end
 
     subgraph FutureAdapter["Future bounded-context adopter"]
@@ -113,15 +119,19 @@ flowchart LR
     WriteApi --> DomainEvent
     WriteApi --> OdmFlush
     OdmFlush --> InvalidationListener
-    InvalidationListener --> RuleCollection
+    CustomerRepository --> CustomRepoFallback
+    CustomRepoFallback --> InvalidationCommand
+    InvalidationListener --> InvalidationCommand
+    InvalidationCommand --> InvalidationHandler
+    InvalidationHandler --> RuleCollection
     RuleCollection --> CustomerInvalidationRules
     CustomerInvalidationRules --> CustomerInvalidationResolver
-    InvalidationListener --> TagResolver
+    InvalidationHandler --> TagResolver
     CustomerInvalidationResolver --> TagResolver
     TagResolver --> TagSetDto
     TagSetDto --> CachePools
-    InvalidationListener --> RefreshCommand
-    InvalidationListener --> Metrics
+    InvalidationHandler --> RefreshCommand
+    InvalidationHandler --> Metrics
 
     DomainEvent --> EventEnvelope
     EventEnvelope --> EventQueue
@@ -132,7 +142,7 @@ flowchart LR
 
     CustomerSubscriber --> AbstractSubscriber
     FutureSubscriber --> AbstractSubscriber
-    AbstractSubscriber --> CachePools
+    AbstractSubscriber --> InvalidationCommand
     AbstractSubscriber --> TargetResolver
     CustomerTargetResolver --> TargetResolver
     AbstractSubscriber --> AbstractFactory
@@ -182,8 +192,10 @@ src/
   Shared/
     Application/
       Command/
+        CacheInvalidationCommand.php
         CacheRefreshCommand.php
       CommandHandler/
+        CacheInvalidationCommandHandler.php
         AbstractCacheRefreshCommandHandler.php
         CacheRefreshCommandHandler.php
       DTO/
@@ -242,6 +254,9 @@ src/
           CustomerCacheTagCollection.php (existing)
         Repository/
           CachedCustomerRepository.php (edit)
+          MongoCustomerRepository.php (review custom write methods for ODM visibility)
+          MongoStatusRepository.php (review custom write methods for ODM visibility)
+          MongoTypeRepository.php (review custom write methods for ODM visibility)
         Resolver/
           CustomerCacheInvalidationTagResolver.php
           CustomerCachePolicyResolver.php
@@ -257,8 +272,10 @@ tests/
     Shared/
       Application/
         Command/
+          CacheInvalidationCommandTest.php
           CacheRefreshCommandTest.php
         CommandHandler/
+          CacheInvalidationCommandHandlerTest.php
           AbstractCacheRefreshCommandHandlerTest.php
           CacheRefreshCommandHandlerTest.php
         DTO/
@@ -309,6 +326,7 @@ tests/
         Repository/
           AutomaticCustomerCacheInvalidationTest.php
           CachedCustomerRepositoryPolicyTest.php
+          CustomerCustomRepositoryInvalidationCoverageTest.php
         Resolver/
           CustomerCacheInvalidationTagResolverTest.php
           CustomerCachePolicyResolverTest.php
@@ -318,6 +336,8 @@ tests/
       Infrastructure/
         Repository/
           AsyncCustomerCacheRefreshTest.php
+          CustomerCustomRepositoryInvalidationCoverageTest.php
+          CustomerDomainEventCacheInvalidationTest.php
 ```
 
 Configuration and documentation expected to change in the later implementation PR:
@@ -342,6 +362,24 @@ docs/
 
 ## Shared Components
 
+### Invalidation Coverage Model
+
+All automatic invalidation sources should normalize into one idempotent invalidation path:
+
+1. **Domain event signal**: when a domain event is exposed, `AbstractCacheInvalidationSubscriber` maps the event to a `CacheInvalidationCommand`. This clears affected tags and can schedule refresh work. This path covers business events and cross-context side effects.
+2. **ODM entity-change signal**: when Doctrine MongoDB ODM flushes managed document insertions, updates, or deletions, `CacheInvalidationDoctrineEventListener` maps UnitOfWork change sets to the same `CacheInvalidationCommand`. This path covers normal repository writes and custom repository methods that still persist/remove managed documents and flush.
+3. **Custom repository fallback signal**: when a custom repository method performs a bulk update/delete, direct query builder write, or external database operation that ODM cannot observe as managed document changes, that repository method must call the shared invalidation command after the write succeeds.
+
+The command/handler path is intentionally idempotent. If a write both changes an ODM document and exposes a domain event, duplicate invalidation of the same tags is acceptable and should not break writes. Refresh scheduling should include a deterministic dedupe key based on context, family, target identifiers, source event ID or write operation ID, and refresh source so duplicate signals do not create unbounded duplicate jobs.
+
+Coverage rules:
+
+- Managed ODM insert/update/delete: automatic through the ODM listener.
+- Custom repository methods that load a document, remove or persist it, and flush: automatic through the ODM listener.
+- Custom repository methods that bypass UnitOfWork change sets: explicit repository fallback to the shared invalidation command is required.
+- Exposed domain events: automatic through domain-event subscribers, independent of whether the ODM listener also observed the write.
+- Writes performed outside this service or directly against the database cannot be fully automatic inside this service; they require an integration event, a repository fallback, or an operational cache-clear command.
+
 ### Automatic CRUD Invalidation
 
 `CacheInvalidationDoctrineEventListener` should be the generic write-side invalidation point for CRUD operations. It belongs in `Shared/Infrastructure/EventListener` because it depends on Doctrine MongoDB ODM flush lifecycle details.
@@ -352,12 +390,35 @@ The listener should:
 2. Read document class, operation type, identifier, and change-set values.
 3. Resolve cache tags through a context-provided rule collection and tag resolver.
 4. Collect invalidation work during flush and invalidate tags only after a successful flush.
-5. Optionally enqueue `CacheRefreshCommand` jobs for policies whose refresh source is `repository_refresh`.
+5. Create a `CacheInvalidationCommand` and let the shared handler clear tags and optionally enqueue `CacheRefreshCommand` jobs for policies whose refresh source is `repository_refresh`.
 6. Emit invalidation and scheduling metrics without failing completed business writes.
 
-This is preferred over a per-entity cache repository or a Domain repository interface change because it covers `BaseRepository::save()`, `BaseRepository::delete()`, and custom infrastructure delete methods that still flush through ODM. A repository base-class hook can be a fallback only for writes that bypass ODM lifecycle events.
+This is preferred over a per-entity cache repository or a Domain repository interface change because it covers `BaseRepository::save()`, `BaseRepository::delete()`, and custom infrastructure delete methods that still flush through ODM. Repository-level fallback calls are required only for writes that bypass ODM lifecycle events.
 
 Context-specific mapping remains thin. For Customer, `CustomerCacheInvalidationRuleCollection` and `CustomerCacheInvalidationTagResolver` should map Customer document changes to existing customer ID, email, and collection tags. Update operations must invalidate both previous and current email tags when email changes.
+
+### Generic Invalidation Command
+
+`CacheInvalidationCommand` is the synchronous shared invalidation request used by all trigger sources. It should carry scalar, serialization-stable data only:
+
+- context name
+- source type, such as `domain_event`, `odm_change_set`, or `repository_fallback`
+- document class or event class
+- operation, such as `created`, `updated`, `deleted`, `bulk_updated`, or `bulk_deleted`
+- target identifiers as a string map
+- changed field names and old/new scalar values where available
+- source event ID or write operation ID
+- deterministic dedupe key
+
+`CacheInvalidationCommandHandler` should:
+
+1. Resolve invalidation rules by context, source type, document or event class, operation, and changed fields.
+2. Resolve concrete tags through the context tag resolver.
+3. Invalidate tags best-effort after the write or event is known to be successful.
+4. Schedule refresh commands only for policies that support proactive refresh.
+5. Emit shared invalidation scheduled/succeeded/failed metrics.
+
+The command should be callable directly from the ODM listener, domain event subscribers, and custom repository fallback paths. It should not require a per-entity cache repository.
 
 ### Generic Refresh Command
 
@@ -378,13 +439,13 @@ The default refresh source for issue #176 is `repository_refresh`: the worker re
 
 ### Abstract Subscriber Contract
 
-`AbstractCacheInvalidationSubscriber` should handle domain-event-driven invalidation and refresh scheduling for events that need more than CRUD write detection. It is not the only invalidation path; `CacheInvalidationDoctrineEventListener` owns automatic CRUD invalidation.
+`AbstractCacheInvalidationSubscriber` should handle domain-event-driven invalidation and refresh scheduling for every domain event that declares cache impact. It is not the only invalidation path; `CacheInvalidationDoctrineEventListener` owns ODM entity-change invalidation, and custom repository fallback calls cover writes that ODM cannot observe.
 
 The subscriber should handle the common sequence:
 
 1. Resolve affected cache targets from the domain event.
-2. Invalidate tags immediately.
-3. Create one or more `CacheRefreshCommand` instances.
+2. Create a `CacheInvalidationCommand` with source type `domain_event`.
+3. Let `CacheInvalidationCommandHandler` invalidate tags and create one or more `CacheRefreshCommand` instances where policy allows.
 4. Dispatch refresh commands best-effort.
 5. Emit scheduled or failed metrics without breaking domain-event processing.
 
@@ -454,7 +515,8 @@ Do not create per-domain cache-refresh queues in the first implementation. A sin
 Customer should be the first adapter for the shared design:
 
 - Customer CRUD invalidation uses the shared ODM listener plus Customer invalidation rules/resolvers.
-- Customer create/update/delete subscribers can remain as domain-event adapters for scheduling or cross-context behavior, but they should not be required for same-aggregate CRUD cache tag invalidation.
+- Customer create/update/delete subscribers remain domain-event adapters and must invalidate the same affected tags through the shared invalidation command when those events are exposed.
+- Duplicate signals from Customer domain events and ODM change sets are expected to be safe because invalidation is idempotent and refresh jobs use deterministic dedupe keys.
 - `CustomerCacheRefreshCommandFactory` creates generic `CacheRefreshCommand` instances from Customer events.
 - `CustomerCacheRefreshTargetResolver` maps target DTOs to Customer repository lookup inputs.
 - `CustomerCacheInvalidationRuleCollection` maps Customer document operations and changed fields to invalidation rules.
@@ -462,6 +524,10 @@ Customer should be the first adapter for the shared design:
 - `CustomerCachePolicyCollection` declares Customer detail, lookup, collection, reference, and negative lookup policies.
 - `CustomerCacheRefreshCommandHandler` extends or composes `AbstractCacheRefreshCommandHandler` and registers for `customer` context families.
 - `CachedCustomerRepository` consumes the shared policy resolver and key builder instead of method-local TTL literals.
+- Existing custom repository methods must be reviewed:
+  - `MongoCustomerRepository::deleteByEmail()` and `deleteById()` load managed Customer documents and delegate to delete, so the ODM listener should cover them.
+  - `MongoTypeRepository::deleteByValue()` and `MongoStatusRepository::deleteByValue()` remove managed documents and flush, so the ODM listener should cover them.
+  - Any future bulk repository method that bypasses managed documents must call `CacheInvalidationCommandHandler` as a repository fallback after the write succeeds.
 
 The first implementation should refresh currently cached same-entity families:
 
@@ -490,21 +556,25 @@ Place them under `Shared/Application/Observability/Metric`. Use dimensions such 
 - Cache failures fall back to the inner repository where the current repository already does so.
 - ODM listener collection happens during flush, but cache invalidation runs only after a successful flush so failed writes do not evict good cache entries.
 - ODM listener invalidation or scheduling failures are logged and measured after the write succeeds; they do not roll back a completed business write.
+- Repository fallback invalidation must run only after the custom write succeeds. Its failures are logged and measured but do not roll back completed writes.
 - Subscriber dispatch failures are logged and measured but do not break domain-event handling.
+- Duplicate invalidation signals from domain events, ODM change sets, and repository fallbacks are allowed. Cache tag invalidation is idempotent; refresh scheduling should be deduplicated.
 - Worker refresh failures are logged and measured; retry and failed routing are controlled by Messenger.
 - Delete events invalidate and avoid warming deleted entities.
 - Domain remains free of Symfony, cache, Messenger, logging, and metrics dependencies.
 
 ## Implementation Sequence
 
-1. Add shared DTOs, resolver interfaces, collections, abstract subscriber, abstract factory, generic refresh command, generic worker, abstract context handler, ODM invalidation listener, and shared metrics.
-2. Add generic invalidation rule/tag resolution and Customer invalidation rules for CRUD create/update/delete change sets.
-3. Add the single `cache-refresh` and `failed-cache-refresh` Messenger transports.
-4. Add Customer adapter classes that extend or compose the shared abstractions.
-5. Update `CachedCustomerRepository` to use resolved policies and generic key helpers.
-6. Update Customer subscribers only for domain-event scheduling needs that are not already handled by automatic CRUD invalidation.
-7. Add unit and integration tests for shared orchestration, automatic CRUD invalidation, and the Customer adapter.
-8. Update docs and run cache performance evidence where runtime services allow.
+1. Add shared DTOs, resolver interfaces, collections, abstract subscriber, abstract factory, generic invalidation command, generic refresh command, generic workers/handlers, abstract context handler, ODM invalidation listener, and shared metrics.
+2. Add generic invalidation rule/tag resolution and Customer invalidation rules for domain events plus CRUD create/update/delete change sets.
+3. Add deterministic invalidation/refresh dedupe keys so domain-event and ODM signals can safely overlap.
+4. Review custom repository methods and add repository fallback invalidation only where a write bypasses ODM managed document change sets.
+5. Add the single `cache-refresh` and `failed-cache-refresh` Messenger transports.
+6. Add Customer adapter classes that extend or compose the shared abstractions.
+7. Update `CachedCustomerRepository` to use resolved policies and generic key helpers.
+8. Update Customer subscribers to route exposed domain events through the shared invalidation command.
+9. Add unit and integration tests for shared orchestration, domain-event invalidation, automatic ODM invalidation, repository fallback coverage, and the Customer adapter.
+10. Update docs and run cache performance evidence where runtime services allow.
 
 ## Architectural Tradeoffs
 
@@ -512,5 +582,7 @@ Place them under `Shared/Application/Observability/Metric`. Use dimensions such 
 - It uses the existing CQRS command/handler names instead of inventing `Request`, `Message`, `MessageHandler`, `Scheduler`, or `Worker` directories.
 - It uses `Policy` as a DTO class name, not as a new directory type.
 - It avoids `ReadModel` because the current project read paths are repository and resolver based, and issue #176 is about refreshing endpoint cache entries rather than introducing a separate projection model.
-- It chooses an ODM flush listener for automatic CRUD invalidation because it can observe all flushed document changes and old/new values. An abstract repository invalidation base is narrower and can miss custom infrastructure methods or direct `DocumentManager` writes.
+- It chooses an ODM flush listener as the primary entity-change invalidation layer because it can observe flushed document changes and old/new values across normal and custom repositories that use managed documents.
+- It keeps domain events as a required invalidation layer when events are exposed, because events capture business meaning and cross-context effects that a raw document change set may not express.
+- It adds repository fallback invalidation only for custom write methods that bypass ODM change sets. This covers edge cases without requiring per-entity cache repositories for normal writes.
 - It keeps repository interfaces cache-free. Cache invalidation mapping is expressed through infrastructure resolver and collection classes, not Domain contracts.

--- a/specs/issue-176-async-cache-refresh/architecture.md
+++ b/specs/issue-176-async-cache-refresh/architecture.md
@@ -1,0 +1,259 @@
+# Architecture: Async Endpoint Cache Refresh
+
+## Current Architecture Fit
+
+The implementation should extend the existing hexagonal/CQRS setup:
+
+- Domain events stay in `src/Core/Customer/Domain/Event`.
+- Event subscribers stay in `src/Core/Customer/Application/EventSubscriber`.
+- Cache policy, scheduling, and refresh handling belong in `Infrastructure/Cache` because they coordinate Symfony Cache, Messenger, and Redis/SQS concerns.
+- Application subscribers can call Infrastructure cache services under the current deptrac rules, but new classes must still use directories captured by `deptrac.yaml`.
+- Cache repository decorator remains in `Infrastructure/Repository`.
+- Messenger transport and handler wiring stay in Symfony configuration.
+
+## Architecture Diagram
+
+```mermaid
+flowchart LR
+    subgraph Domain["Domain layer (framework-free)"]
+        DomainEvents["CustomerCreatedEvent\nCustomerUpdatedEvent\nCustomerDeletedEvent"]
+    end
+
+    subgraph Application["Customer Application layer"]
+        Subscribers["Customer cache invalidation subscribers"]
+        Message["CustomerCacheRefreshMessage"]
+        Metrics["Customer cache metric classes"]
+    end
+
+    subgraph Infrastructure["Infrastructure layer"]
+        PolicyRegistry["CustomerCachePolicyRegistry"]
+        Scheduler["CustomerCacheRefreshScheduler"]
+        Handler["CustomerCacheRefreshMessageHandler"]
+        CachedRepo["CachedCustomerRepository"]
+        InnerRepo["MongoCustomerRepository"]
+        KeyBuilder["CacheKeyBuilder"]
+        TagResolver["CustomerCacheTagResolver"]
+        CachePools["Redis tag-aware cache pools\ncustomer detail, lookup, collection, reference"]
+        Messenger["Symfony Messenger"]
+        Sqs["SQS transport\nLocalStack locally"]
+    end
+
+    subgraph Observability["Shared observability"]
+        Emitter["BusinessMetricsEmitterInterface"]
+    end
+
+    WriteApi["Customer write API\ncommand handlers"] --> DomainEvents
+    DomainEvents --> Messenger
+    Messenger --> Subscribers
+    Subscribers --> TagResolver
+    Subscribers --> CachePools
+    Subscribers --> Scheduler
+    Scheduler --> PolicyRegistry
+    Scheduler --> Message
+    Message --> Messenger
+    Messenger --> Sqs
+    Sqs --> Handler
+    Handler --> PolicyRegistry
+    Handler --> InnerRepo
+    Handler --> KeyBuilder
+    Handler --> CachePools
+
+    ReadApi["Customer read API"] --> CachedRepo
+    CachedRepo --> PolicyRegistry
+    CachedRepo --> KeyBuilder
+    CachedRepo --> CachePools
+    CachedRepo --> InnerRepo
+
+    CachedRepo --> Metrics
+    Scheduler --> Metrics
+    Handler --> Metrics
+    Metrics --> Emitter
+```
+
+Read requests continue to use the cache repository decorator. Write-side domain events invalidate affected tags and schedule same-entity refresh messages. Refresh workers warm customer detail and email lookup cache entries through the inner repository without blocking business writes.
+
+## Planned Source Tree
+
+The implementation PR should add the following source files. Existing files that need edits are listed separately below.
+
+```text
+src/
+  Core/
+    Customer/
+      Application/
+        Message/
+          CustomerCacheRefreshMessage.php
+        Metric/
+          CustomerCacheHitMetric.php
+          CustomerCacheMetricDimensions.php
+          CustomerCacheMissMetric.php
+          CustomerCacheRefreshFailedMetric.php
+          CustomerCacheRefreshScheduledMetric.php
+          CustomerCacheRefreshSucceededMetric.php
+          CustomerCacheStaleServedMetric.php
+      Infrastructure/
+        Cache/
+          CustomerCacheConsistency.php
+          CustomerCacheFamily.php
+          CustomerCachePolicy.php
+          CustomerCachePolicyCollection.php
+          CustomerCachePolicyRegistry.php
+          CustomerCachePolicyRegistryInterface.php
+          CustomerCacheRefreshMessageHandler.php
+          CustomerCacheRefreshScheduler.php
+          CustomerCacheRefreshSchedulerInterface.php
+          CustomerCacheRefreshStrategy.php
+```
+
+This layout matches the existing `deptrac.yaml` collectors:
+
+- `Application/Message` and `Application/Metric` are collected as Application.
+- `Infrastructure/Cache` is collected as Infrastructure.
+- `Application/Cache`, `Application/Scheduler`, and `Application/MessageHandler` are intentionally avoided because they are not collected by the current deptrac configuration.
+
+Planned test files:
+
+```text
+tests/
+  Unit/
+    Customer/
+      Application/
+        EventSubscriber/
+          CustomerCreatedCacheInvalidationSubscriberTest.php
+          CustomerDeletedCacheInvalidationSubscriberTest.php
+          CustomerUpdatedCacheInvalidationSubscriberTest.php
+        Message/
+          CustomerCacheRefreshMessageTest.php
+        Metric/
+          CustomerCacheMetricTest.php
+      Infrastructure/
+        Cache/
+          CustomerCachePolicyRegistryTest.php
+          CustomerCachePolicyTest.php
+          CustomerCacheRefreshMessageHandlerTest.php
+          CustomerCacheRefreshSchedulerTest.php
+        Repository/
+          CachedCustomerRepositoryPolicyTest.php
+  Integration/
+    Customer/
+      Infrastructure/
+        Cache/
+          AsyncCustomerCacheRefreshTest.php
+```
+
+Configuration and existing files expected to change:
+
+```text
+config/
+  packages/
+    cache.yaml
+    messenger.yaml
+  packages/test/
+    cache.yaml
+    messenger.yaml (new, only if test routing cannot stay in messenger.yaml)
+  services.yaml
+.env
+.env.test
+src/
+  Core/
+    Customer/
+      Application/
+        EventSubscriber/
+          CustomerCreatedCacheInvalidationSubscriber.php
+          CustomerDeletedCacheInvalidationSubscriber.php
+          CustomerUpdatedCacheInvalidationSubscriber.php
+      Infrastructure/
+        Repository/
+          CachedCustomerRepository.php
+docs/
+  advanced-configuration.md
+  design-and-architecture.md
+  operational.md
+  performance.md
+```
+
+## Proposed Components
+
+### Cache Policy Model
+
+Add typed policy classes in `src/Core/Customer/Infrastructure/Cache`:
+
+- `CustomerCacheFamily`
+- `CustomerCacheConsistency`
+- `CustomerCacheRefreshStrategy`
+- `CustomerCachePolicy`
+- `CustomerCachePolicyRegistry`
+- `CustomerCachePolicyRegistryInterface`
+- optional typed collection for registry construction
+
+Use services.yaml arguments for TTLs/jitter so defaults are configurable without editing repository code.
+
+### Cache Refresh Message Path
+
+Add a dedicated message model:
+
+- `CustomerCacheRefreshMessage` in `src/Core/Customer/Application/Message`
+- `CustomerCacheRefreshMessageHandler` in `src/Core/Customer/Infrastructure/Cache`
+- `CustomerCacheRefreshScheduler` in `src/Core/Customer/Infrastructure/Cache`
+
+The message should carry scalar payload only, such as family name, customer ID, email, and event metadata, so it remains stable across Messenger serialization. The scheduler dispatches messages through `MessageBusInterface` and catches dispatch failures. The handler warms same-entity entries from the underlying persisted state, such as customer detail by ID and lookup by email. For delete events, it should avoid warming deleted entities and may schedule only collection/reference policy refresh markers where safe.
+
+### Repository Decorator Changes
+
+Update `CachedCustomerRepository` to inject:
+
+- detail cache pool
+- lookup cache pool
+- policy registry
+- metrics emitter or cache metrics service
+
+Use the policy registry for TTL, tags, and cache key metadata. Preserve existing `findFresh()` bypass behavior for write paths.
+
+### Messenger Configuration
+
+Add:
+
+- `CACHE_REFRESH_QUEUE_NAME`
+- `FAILED_CACHE_REFRESH_QUEUE_NAME`
+- `CACHE_REFRESH_TRANSPORT_DSN`
+- `FAILED_CACHE_REFRESH_TRANSPORT_DSN`
+- `cache-refresh` transport
+- `failed-cache-refresh` transport
+- routing for `CustomerCacheRefreshMessage`
+
+In `when@test`, route cache refresh to in-memory transport.
+
+### Observability
+
+Add typed metrics under `src/Core/Customer/Application/Metric` or shared observability if reusable:
+
+- `CustomerCacheRefreshScheduledMetric`
+- `CustomerCacheRefreshSucceededMetric`
+- `CustomerCacheRefreshFailedMetric`
+- `CustomerCacheHitMetric`
+- `CustomerCacheMissMetric`
+- `CustomerCacheStaleServedMetric`
+
+Prefer a `CustomerCacheMetricDimensions` value object with `Endpoint=CustomerCache`, `Operation=<operation>`, `Family=<family>`.
+
+### Failure Semantics
+
+- Repository cache failures fall back to the inner repository.
+- Scheduler failures log and emit a failure metric, then return.
+- Handler failures log and emit a failure metric, then return so poison refresh jobs do not block business behavior.
+- Domain event subscribers remain resilient through the existing `DomainEventMessageHandler`.
+
+## Implementation Sequence
+
+1. Add policy model and tests.
+2. Split cache pools and update repository TTL usage.
+3. Add refresh message/scheduler/handler and Messenger routing.
+4. Update subscribers to invalidate plus schedule.
+5. Add metrics and tests.
+6. Add integration proof and docs.
+7. Run CI and cache performance evidence.
+
+## Architectural Tradeoffs
+
+- The first PR should not attempt generic API Platform collection caching. That requires a provider-level design and may be a separate architecture change.
+- Reference-data policies can be declared before reference-data domain events exist. Full refresh triggering for type/status mutations should be follow-up work unless events are added in this PR.

--- a/specs/issue-176-async-cache-refresh/epics.md
+++ b/specs/issue-176-async-cache-refresh/epics.md
@@ -16,7 +16,8 @@ Story 1.2: Add generic command and abstract orchestration classes.
 
 Acceptance:
 
-- Abstract subscriber invalidates tags, resolves targets, dispatches refresh commands, and emits metrics.
+- `CacheInvalidationCommand` and `CacheInvalidationCommandHandler` provide one idempotent tag-clearing entrypoint for domain events, ODM changes, and repository fallbacks.
+- Abstract subscriber maps exposed domain events to invalidation commands, resolves targets, dispatches refresh commands, and emits metrics.
 - Abstract factory creates scalar, Messenger-safe `CacheRefreshCommand` payloads.
 - Generic `CacheRefreshCommandHandler` is the single worker entrypoint for the shared queue.
 - Abstract context handler resolves policy and target, executes `repository_refresh`, `event_snapshot`, or `invalidate_only`, and returns a result.
@@ -31,6 +32,16 @@ Acceptance:
 - Change-set handling supports old and new indexed values, including previous and current email-style tags.
 - Listener failures are logged and measured but do not roll back completed writes.
 - Unit tests cover insert, update, delete, no-op, failure, and refresh scheduling cases.
+
+Story 1.4: Add repository fallback coverage for custom writes.
+
+Acceptance:
+
+- Custom repository methods are classified as ODM-observed or repository-fallback required.
+- Methods that load managed documents and flush are documented as covered by the ODM listener.
+- Methods that perform bulk or direct database writes call the shared invalidation command after successful write completion.
+- Repository fallback failures are best effort and do not roll back completed writes.
+- Unit tests cover at least one fallback path and prove fallback uses the same rules/resolvers as ODM and domain-event invalidation.
 
 ## Epic 2: Add Shared Queue and Worker Path
 
@@ -73,6 +84,15 @@ Acceptance:
 - Delete invalidates and uses `invalidate_only` behavior instead of warming deleted entities.
 - Scheduling failure is best effort.
 
+Story 3.2a: Verify Customer custom repository coverage.
+
+Acceptance:
+
+- `MongoCustomerRepository::deleteByEmail()` and `deleteById()` are covered by ODM listener behavior because they load managed documents and delegate deletion.
+- `MongoTypeRepository::deleteByValue()` and `MongoStatusRepository::deleteByValue()` are covered by ODM listener behavior because they remove managed documents and flush.
+- If any Customer repository method bypasses ODM managed document change sets during implementation, it calls the shared invalidation command as a fallback.
+- Tests prove Customer custom delete methods clear the same tags as normal save/delete paths.
+
 Story 3.3: Add Customer refresh command handler adapter.
 
 Acceptance:
@@ -83,12 +103,13 @@ Acceptance:
 - Context-specific logic is limited to target mapping and repository loading.
 - Current Customer events are not used for event-only refresh because they do not carry complete Customer cache snapshots.
 
-Story 3.4: Keep Customer event subscribers narrow.
+Story 3.4: Keep Customer event subscribers as automatic domain-event invalidation.
 
 Acceptance:
 
-- Existing Customer create/update/delete subscribers are reduced to domain-event scheduling responsibilities that are not already covered by automatic CRUD invalidation.
-- Subscribers do not duplicate tag invalidation already performed by the ODM listener unless an implementation test proves a non-ODM write path needs the fallback.
+- Existing Customer create/update/delete subscribers route exposed domain events to the shared invalidation command.
+- Subscribers may overlap with ODM invalidation, and that overlap is safe because invalidation is idempotent.
+- Refresh scheduling uses deterministic dedupe keys so overlapping domain-event and ODM signals do not create unbounded duplicate jobs.
 - Subscriber failures remain isolated from domain-event processing.
 
 ## Epic 4: Observability and Evidence
@@ -107,6 +128,8 @@ Acceptance:
 
 - Integration tests prove post-write cache warmup without a user read doing the expensive refresh.
 - Integration tests prove automatic CRUD invalidation after create/update/delete without a per-entity cache repository.
+- Integration tests prove exposed domain events invalidate cache even when the event is the only available signal.
+- Integration tests or unit tests prove custom repository fallback coverage for any write path not observed by ODM.
 - Existing cache performance integration and K6 smoke targets are run or a blocker is documented.
 
 ## Epic 5: Documentation and CI

--- a/specs/issue-176-async-cache-refresh/epics.md
+++ b/specs/issue-176-async-cache-refresh/epics.md
@@ -1,0 +1,79 @@
+# Epics and Stories
+
+## Epic 1: Declare Cache Policy Contract
+
+Story 1.1: Add typed customer cache family, consistency, refresh strategy, and policy objects.
+
+Acceptance:
+
+- Policies expose key namespace, tags, soft TTL, hard TTL, jitter, consistency class, and refresh strategy.
+- TTL jitter is deterministic enough to test and bounded by policy.
+- Unit tests cover policy construction and registry lookup.
+
+Story 1.2: Wire policy registry through Symfony services.
+
+Acceptance:
+
+- TTL/jitter defaults are configurable through parameters/env-backed service arguments.
+- Customer detail/email repository cache uses registry values instead of literals.
+
+## Epic 2: Add Async Refresh Pipeline
+
+Story 2.1: Add cache refresh message, scheduler, and handler.
+
+Acceptance:
+
+- Scheduler dispatches dedicated cache refresh messages through Messenger.
+- Handler warms customer detail and email lookup entries from persisted state.
+- Handler logs and emits failure metrics without throwing into business behavior.
+
+Story 2.2: Add SQS runtime and LocalStack local routing.
+
+Acceptance:
+
+- Non-test config routes refresh messages to an SQS-backed transport.
+- Test config uses in-memory transport.
+- Existing domain event routing remains unchanged.
+
+## Epic 3: Connect Domain Events to Refresh Work
+
+Story 3.1: Update customer create/update/delete cache subscribers.
+
+Acceptance:
+
+- Subscribers invalidate affected tags.
+- Create/update events schedule detail and email refresh work.
+- Update with email change handles previous and current email families correctly.
+- Delete avoids warming deleted entities and keeps invalidation behavior.
+- Scheduling failure is best effort.
+
+## Epic 4: Observability and Evidence
+
+Story 4.1: Add typed cache lifecycle metrics.
+
+Acceptance:
+
+- Scheduled, success, failure, hit, miss, and stale-served metrics exist as typed classes.
+- Unit tests cover names, units, and dimensions.
+
+Story 4.2: Add integration and performance proof.
+
+Acceptance:
+
+- Integration tests prove post-event cache warmup without a user read doing the expensive refresh.
+- Existing cache performance integration and K6 smoke targets are run or a blocker is documented.
+
+## Epic 5: Documentation and CI
+
+Story 5.1: Document cache policies and operations.
+
+Acceptance:
+
+- Docs describe TTL defaults, stale-read risk, SQS refresh transport, LocalStack, and metrics.
+
+Story 5.2: Validate the PR.
+
+Acceptance:
+
+- `make ci` passes.
+- GitHub PR is opened, CI is green, and review comments are addressed.

--- a/specs/issue-176-async-cache-refresh/epics.md
+++ b/specs/issue-176-async-cache-refresh/epics.md
@@ -1,59 +1,82 @@
 # Epics and Stories
 
-## Epic 1: Declare Cache Policy Contract
+## Epic 1: Create Shared Cache Refresh Contract
 
-Story 1.1: Add typed customer cache policy DTO, factory, collection, and resolver.
-
-Acceptance:
-
-- Policies expose key namespace, tags, soft TTL, hard TTL, jitter, consistency class, and refresh strategy.
-- TTL jitter is deterministic enough to test and bounded by policy.
-- Unit tests cover policy construction, collection lookup, and resolver behavior.
-
-Story 1.2: Wire policy collection and resolver through Symfony services.
+Story 1.1: Add shared cache-refresh DTOs, resolver interfaces, collections, and metrics.
 
 Acceptance:
 
-- TTL/jitter defaults are configurable through parameters/env-backed service arguments.
-- Customer detail/email repository cache uses resolved policy values instead of literals.
+- `CacheRefreshPolicy`, `CacheRefreshTarget`, and `CacheRefreshResult` are shared DTOs.
+- Policy and target resolver interfaces are shared and context-agnostic.
+- Shared metric classes cover scheduled, succeeded, failed, hit, miss, and stale-served lifecycle events.
+- Unit tests cover construction, validation, and metric dimensions.
 
-## Epic 2: Add Async Refresh Pipeline
-
-Story 2.1: Add cache refresh command, command factory, target resolver, and command handler.
-
-Acceptance:
-
-- Subscribers dispatch dedicated refresh commands through Messenger or the configured command path.
-- Command handler warms customer detail and email lookup entries from persisted state.
-- Command handler logs and emits failure metrics without throwing into business behavior.
-
-Story 2.2: Add SQS runtime and LocalStack local routing.
+Story 1.2: Add generic command and abstract orchestration classes.
 
 Acceptance:
 
-- Non-test config routes refresh commands to an SQS-backed transport.
-- Test config uses in-memory transport.
-- Existing domain event routing remains unchanged.
+- Abstract subscriber invalidates tags, resolves targets, dispatches refresh commands, and emits metrics.
+- Abstract factory creates scalar, Messenger-safe `RefreshCacheCommand` payloads.
+- Generic `RefreshCacheCommandHandler` is the single worker entrypoint for the shared queue.
+- Abstract context handler resolves policy and target, refreshes cache through context callbacks, and returns a result.
+- Unit tests prove the shared classes are reusable without Customer-specific types.
 
-## Epic 3: Connect Domain Events to Refresh Work
+## Epic 2: Add Shared Queue and Worker Path
 
-Story 3.1: Update customer create/update/delete cache subscribers.
+Story 2.1: Add cache refresh Messenger routing.
 
 Acceptance:
 
-- Subscribers invalidate affected tags.
+- Non-test config routes refresh commands to one SQS-backed `cache-refresh` transport.
+- Failed jobs route to `failed-cache-refresh`.
+- Test config uses deterministic in-memory routing.
+- Existing `domain-events` routing remains unchanged.
+
+Story 2.2: Document operational worker usage.
+
+Acceptance:
+
+- Documentation explains the difference between domain-event workers and cache-refresh workers.
+- LocalStack variables and runtime variables are documented.
+- Per-domain queues are explicitly deferred until metrics justify them.
+
+## Epic 3: Add Customer as the First Adapter
+
+Story 3.1: Declare Customer policies and target resolution using existing directories.
+
+Acceptance:
+
+- Customer uses existing `Application/Factory`, `Infrastructure/Collection`, and `Infrastructure/Resolver` directories.
+- Customer detail, lookup, collection, reference, and negative lookup policies are declared.
+- `CachedCustomerRepository` uses resolved policies instead of hardcoded TTL literals.
+
+Story 3.2: Connect Customer events to shared refresh orchestration.
+
+Acceptance:
+
+- Customer create/update/delete subscribers extend or delegate to the abstract subscriber.
 - Create/update events schedule detail and email refresh work.
 - Update with email change handles previous and current email families correctly.
-- Delete avoids warming deleted entities and keeps invalidation behavior.
+- Delete invalidates and avoids warming deleted entities.
 - Scheduling failure is best effort.
+
+Story 3.3: Add Customer refresh command handler adapter.
+
+Acceptance:
+
+- `CustomerCacheRefreshCommandFactory` creates the shared `RefreshCacheCommand` payload without Customer-specific fields in the payload contract.
+- `CustomerCacheRefreshCommandHandler` extends or composes the shared abstract context handler.
+- The handler warms Customer detail and email lookup entries from persisted state.
+- Context-specific logic is limited to target mapping and repository loading.
 
 ## Epic 4: Observability and Evidence
 
-Story 4.1: Add typed cache lifecycle metrics.
+Story 4.1: Add shared cache lifecycle metrics.
 
 Acceptance:
 
-- Scheduled, success, failure, hit, miss, and stale-served metrics exist as typed classes.
+- Shared metric classes support context and family dimensions.
+- Customer adapter emits the shared metrics with `customer` context.
 - Unit tests cover names, units, and dimensions.
 
 Story 4.2: Add integration and performance proof.
@@ -65,15 +88,16 @@ Acceptance:
 
 ## Epic 5: Documentation and CI
 
-Story 5.1: Document cache policies and operations.
+Story 5.1: Document reusable cache-refresh architecture.
 
 Acceptance:
 
-- Docs describe TTL defaults, stale-read risk, SQS refresh transport, LocalStack, and metrics.
+- Docs describe shared classes, context adapter responsibilities, TTL defaults, stale-read risk, SQS refresh transport, LocalStack, and metrics.
+- Source-tree documentation shows new shared files and Customer adapter files.
 
 Story 5.2: Validate the PR.
 
 Acceptance:
 
-- `make ci` passes.
-- GitHub PR is opened, CI is green, and review comments are addressed.
+- `make ci` passes or a local environment blocker is documented and GitHub CI is green.
+- GitHub PR is updated, CI is green, and review comments are addressed.

--- a/specs/issue-176-async-cache-refresh/epics.md
+++ b/specs/issue-176-async-cache-refresh/epics.md
@@ -2,36 +2,36 @@
 
 ## Epic 1: Declare Cache Policy Contract
 
-Story 1.1: Add typed customer cache family, consistency, refresh strategy, and policy objects.
+Story 1.1: Add typed customer cache policy DTO, factory, collection, and resolver.
 
 Acceptance:
 
 - Policies expose key namespace, tags, soft TTL, hard TTL, jitter, consistency class, and refresh strategy.
 - TTL jitter is deterministic enough to test and bounded by policy.
-- Unit tests cover policy construction and registry lookup.
+- Unit tests cover policy construction, collection lookup, and resolver behavior.
 
-Story 1.2: Wire policy registry through Symfony services.
+Story 1.2: Wire policy collection and resolver through Symfony services.
 
 Acceptance:
 
 - TTL/jitter defaults are configurable through parameters/env-backed service arguments.
-- Customer detail/email repository cache uses registry values instead of literals.
+- Customer detail/email repository cache uses resolved policy values instead of literals.
 
 ## Epic 2: Add Async Refresh Pipeline
 
-Story 2.1: Add cache refresh message, scheduler, and handler.
+Story 2.1: Add cache refresh command, command factory, target resolver, and command handler.
 
 Acceptance:
 
-- Scheduler dispatches dedicated cache refresh messages through Messenger.
-- Handler warms customer detail and email lookup entries from persisted state.
-- Handler logs and emits failure metrics without throwing into business behavior.
+- Subscribers dispatch dedicated refresh commands through Messenger or the configured command path.
+- Command handler warms customer detail and email lookup entries from persisted state.
+- Command handler logs and emits failure metrics without throwing into business behavior.
 
 Story 2.2: Add SQS runtime and LocalStack local routing.
 
 Acceptance:
 
-- Non-test config routes refresh messages to an SQS-backed transport.
+- Non-test config routes refresh commands to an SQS-backed transport.
 - Test config uses in-memory transport.
 - Existing domain event routing remains unchanged.
 

--- a/specs/issue-176-async-cache-refresh/epics.md
+++ b/specs/issue-176-async-cache-refresh/epics.md
@@ -16,8 +16,8 @@ Story 1.2: Add generic command and abstract orchestration classes.
 Acceptance:
 
 - Abstract subscriber invalidates tags, resolves targets, dispatches refresh commands, and emits metrics.
-- Abstract factory creates scalar, Messenger-safe `RefreshCacheCommand` payloads.
-- Generic `RefreshCacheCommandHandler` is the single worker entrypoint for the shared queue.
+- Abstract factory creates scalar, Messenger-safe `CacheRefreshCommand` payloads.
+- Generic `CacheRefreshCommandHandler` is the single worker entrypoint for the shared queue.
 - Abstract context handler resolves policy and target, refreshes cache through context callbacks, and returns a result.
 - Unit tests prove the shared classes are reusable without Customer-specific types.
 
@@ -64,7 +64,7 @@ Story 3.3: Add Customer refresh command handler adapter.
 
 Acceptance:
 
-- `CustomerCacheRefreshCommandFactory` creates the shared `RefreshCacheCommand` payload without Customer-specific fields in the payload contract.
+- `CustomerCacheRefreshCommandFactory` creates the shared `CacheRefreshCommand` payload without Customer-specific fields in the payload contract.
 - `CustomerCacheRefreshCommandHandler` extends or composes the shared abstract context handler.
 - The handler warms Customer detail and email lookup entries from persisted state.
 - Context-specific logic is limited to target mapping and repository loading.

--- a/specs/issue-176-async-cache-refresh/epics.md
+++ b/specs/issue-176-async-cache-refresh/epics.md
@@ -6,8 +6,9 @@ Story 1.1: Add shared cache-refresh DTOs, resolver interfaces, collections, and 
 
 Acceptance:
 
-- `CacheRefreshPolicy`, `CacheRefreshTarget`, and `CacheRefreshResult` are shared DTOs.
+- `CacheRefreshPolicy`, `CacheRefreshTarget`, `CacheRefreshResult`, `CacheInvalidationRule`, and `CacheInvalidationTagSet` are shared DTOs.
 - Policy and target resolver interfaces are shared and context-agnostic.
+- Invalidation rule and tag resolution contracts are shared and context-agnostic.
 - Shared metric classes cover scheduled, succeeded, failed, hit, miss, and stale-served lifecycle events.
 - Unit tests cover construction, validation, and metric dimensions.
 
@@ -18,8 +19,18 @@ Acceptance:
 - Abstract subscriber invalidates tags, resolves targets, dispatches refresh commands, and emits metrics.
 - Abstract factory creates scalar, Messenger-safe `CacheRefreshCommand` payloads.
 - Generic `CacheRefreshCommandHandler` is the single worker entrypoint for the shared queue.
-- Abstract context handler resolves policy and target, refreshes cache through context callbacks, and returns a result.
+- Abstract context handler resolves policy and target, executes `repository_refresh`, `event_snapshot`, or `invalidate_only`, and returns a result.
 - Unit tests prove the shared classes are reusable without Customer-specific types.
+
+Story 1.3: Add shared automatic CRUD invalidation infrastructure.
+
+Acceptance:
+
+- `CacheInvalidationDoctrineEventListener` observes ODM create/update/delete flushes and invalidates after a successful flush.
+- The listener uses shared invalidation rule and tag resolver classes rather than per-entity cache repositories.
+- Change-set handling supports old and new indexed values, including previous and current email-style tags.
+- Listener failures are logged and measured but do not roll back completed writes.
+- Unit tests cover insert, update, delete, no-op, failure, and refresh scheduling cases.
 
 ## Epic 2: Add Shared Queue and Worker Path
 
@@ -48,16 +59,18 @@ Acceptance:
 
 - Customer uses existing `Application/Factory`, `Infrastructure/Collection`, and `Infrastructure/Resolver` directories.
 - Customer detail, lookup, collection, reference, and negative lookup policies are declared.
+- Customer policies declare refresh source, with detail and lookup using `repository_refresh`.
 - `CachedCustomerRepository` uses resolved policies instead of hardcoded TTL literals.
 
-Story 3.2: Connect Customer events to shared refresh orchestration.
+Story 3.2: Connect Customer CRUD writes to automatic invalidation.
 
 Acceptance:
 
-- Customer create/update/delete subscribers extend or delegate to the abstract subscriber.
-- Create/update events schedule detail and email refresh work.
-- Update with email change handles previous and current email families correctly.
-- Delete invalidates and avoids warming deleted entities.
+- `CustomerCacheInvalidationRuleCollection` and `CustomerCacheInvalidationTagResolver` live in existing Infrastructure collection/resolver directories.
+- Create/update/delete ODM flushes invalidate ID, email, old-email, and collection tags through the shared listener.
+- Create/update writes schedule detail and email refresh work where policy uses `repository_refresh`.
+- Update with email change handles previous and current email families correctly from change-set data.
+- Delete invalidates and uses `invalidate_only` behavior instead of warming deleted entities.
 - Scheduling failure is best effort.
 
 Story 3.3: Add Customer refresh command handler adapter.
@@ -68,6 +81,15 @@ Acceptance:
 - `CustomerCacheRefreshCommandHandler` extends or composes the shared abstract context handler.
 - The handler warms Customer detail and email lookup entries from persisted state.
 - Context-specific logic is limited to target mapping and repository loading.
+- Current Customer events are not used for event-only refresh because they do not carry complete Customer cache snapshots.
+
+Story 3.4: Keep Customer event subscribers narrow.
+
+Acceptance:
+
+- Existing Customer create/update/delete subscribers are reduced to domain-event scheduling responsibilities that are not already covered by automatic CRUD invalidation.
+- Subscribers do not duplicate tag invalidation already performed by the ODM listener unless an implementation test proves a non-ODM write path needs the fallback.
+- Subscriber failures remain isolated from domain-event processing.
 
 ## Epic 4: Observability and Evidence
 
@@ -83,7 +105,8 @@ Story 4.2: Add integration and performance proof.
 
 Acceptance:
 
-- Integration tests prove post-event cache warmup without a user read doing the expensive refresh.
+- Integration tests prove post-write cache warmup without a user read doing the expensive refresh.
+- Integration tests prove automatic CRUD invalidation after create/update/delete without a per-entity cache repository.
 - Existing cache performance integration and K6 smoke targets are run or a blocker is documented.
 
 ## Epic 5: Documentation and CI

--- a/specs/issue-176-async-cache-refresh/implementation-readiness.md
+++ b/specs/issue-176-async-cache-refresh/implementation-readiness.md
@@ -8,10 +8,13 @@ Ready to implement with scoped constraints.
 
 - The existing repository already has the core primitives: Redis tag-aware cache, cache key builder, cached repository decorator, SQS-backed Messenger event bus, LocalStack configuration, EMF metric infrastructure, and cache performance tests.
 - The issue can be delivered without API contract changes.
-- Tests can be deterministic by invoking command factory/handler paths directly while keeping Messenger routing under unit/config coverage.
+- The reusable foundation can reuse existing class-type directories and deptrac-collected namespaces.
+- Tests can be deterministic by invoking the shared worker and Customer handler paths directly while keeping Messenger routing under unit/config coverage.
 
 ## Gaps and Mitigations
 
+- Generic adopter contract needs to stay feature-neutral.
+  - Mitigation: `RefreshCacheCommand` uses context, family, target identifiers, strategy, and event metadata only; Customer-specific meaning stays in Customer factory/resolver/handler classes.
 - Generic collection cache warmup is not currently represented by a stable repository query object.
   - Mitigation: declare collection policy and continue invalidating collection tags; implement same-entity refresh for detail/email families in this PR.
 - Reference-data mutations do not appear to publish domain events.
@@ -22,15 +25,18 @@ Ready to implement with scoped constraints.
 ## Required Validation
 
 - Unit tests:
+  - shared command serialization and scalar payload contract
+  - shared worker delegation and failure isolation
+  - shared abstract subscriber/factory/context handler behavior
   - policy DTO/factory/collection/resolver
   - jitter bounds
   - repository policy usage
-  - refresh command creation
-  - refresh command handler
-  - updated subscribers
+  - Customer refresh command creation
+  - Customer refresh command handler
+  - updated Customer subscribers
   - metrics
 - Integration tests:
-  - event invalidation plus handler refresh repopulates detail/email caches
+  - event invalidation plus shared worker and Customer handler refresh repopulates detail/email caches
   - refresh command dispatch failure does not break subscriber execution
 - Performance/load evidence:
   - `make cache-performance-tests`
@@ -40,4 +46,4 @@ Ready to implement with scoped constraints.
 
 ## Decision
 
-Proceed with implementation. Keep collection/reference full warmup as explicit follow-up unless implementation reveals a safe existing abstraction.
+Proceed with implementation. Deliver the shared reusable refresh foundation and Customer as the first adopter. Keep collection/reference full warmup as explicit follow-up unless implementation reveals a safe existing abstraction.

--- a/specs/issue-176-async-cache-refresh/implementation-readiness.md
+++ b/specs/issue-176-async-cache-refresh/implementation-readiness.md
@@ -11,6 +11,8 @@ Ready to implement with scoped constraints.
 - The reusable foundation can reuse existing class-type directories and deptrac-collected namespaces.
 - Automatic CRUD invalidation can use ODM UnitOfWork/change-set data, which avoids adding cache methods to Domain repository interfaces.
 - The ODM listener can handle old and new indexed values, so email-change invalidation can be generic and correct.
+- The existing domain-event worker already gives a second automatic invalidation signal when business code exposes events.
+- Current Customer custom delete methods still operate on managed ODM documents, so they should be covered by the ODM listener without per-entity cache repositories.
 - Tests can be deterministic by invoking the shared worker and Customer handler paths directly while keeping Messenger routing under unit/config coverage.
 
 ## Gaps and Mitigations
@@ -20,11 +22,13 @@ Ready to implement with scoped constraints.
 - Automatic CRUD invalidation must not become Customer-specific.
   - Mitigation: put the ODM listener in Shared Infrastructure and put Customer mapping in `CustomerCacheInvalidationRuleCollection` and `CustomerCacheInvalidationTagResolver`.
 - ODM lifecycle listeners may not observe direct bulk update/delete operations if they bypass UnitOfWork document change sets.
-  - Mitigation: document that implementation must use repository/DocumentManager paths that flush managed documents, and add explicit fallbacks only when tests identify a bypass.
+  - Mitigation: classify every custom repository write path. Managed document writes rely on the ODM listener; bulk/direct writes must call the shared invalidation command as a repository fallback after successful write completion.
+- Domain-event and ODM signals may overlap for the same write.
+  - Mitigation: make tag invalidation idempotent and add deterministic refresh dedupe keys based on context, family, target identifiers, and source event/write operation.
 - Generic collection cache warmup is not currently represented by a stable repository query object.
   - Mitigation: declare collection policy and continue invalidating collection tags; implement same-entity refresh for detail/email families in this PR.
 - Reference-data mutations do not appear to publish domain events.
-  - Mitigation: declare reference policy and document the gap; avoid speculative reference refresh triggers unless events are added.
+  - Mitigation: use ODM listener rules for managed Customer type/status document changes; add domain events later only for business semantics or cross-context reactions.
 - Event-only cache refresh from current Customer events is unsafe because those events carry identifiers and emails, not complete Customer snapshots.
   - Mitigation: use `repository_refresh` as the default. Reserve `event_snapshot` for future complete, versioned event payloads with stale-overwrite protection.
 - Hit/miss/stale-served metrics may not be fully observable through Symfony cache APIs.
@@ -34,8 +38,11 @@ Ready to implement with scoped constraints.
 
 - Unit tests:
   - shared command serialization and scalar payload contract
+  - shared invalidation command/handler behavior
   - shared worker delegation and failure isolation
   - shared ODM invalidation listener insert/update/delete behavior
+  - domain-event subscriber invalidation through the shared command
+  - repository fallback invalidation for custom writes that bypass ODM observation
   - invalidation rule and tag resolver behavior
   - shared abstract subscriber/factory/context handler behavior
   - policy DTO/factory/collection/resolver
@@ -44,11 +51,14 @@ Ready to implement with scoped constraints.
   - repository policy usage
   - Customer refresh command creation
   - Customer invalidation rules and old/new email tag resolution
+  - Customer custom repository method coverage classification
   - Customer refresh command handler
   - updated Customer subscribers
   - metrics
 - Integration tests:
   - automatic CRUD invalidation plus shared worker and Customer handler refresh repopulates detail/email caches
+  - exposed domain events invalidate affected tags even when no ODM change-set is available
+  - custom repository write paths either trigger ODM invalidation or invoke repository fallback
   - update with email change invalidates previous and current email lookup tags
   - delete invalidates without warming deleted entities
   - refresh command dispatch failure does not break subscriber execution
@@ -60,4 +70,4 @@ Ready to implement with scoped constraints.
 
 ## Decision
 
-Proceed with implementation. Deliver the shared reusable refresh foundation, automatic ODM CRUD invalidation, and Customer as the first adopter. Keep collection/reference full warmup and event-snapshot refresh as explicit follow-ups unless implementation reveals safe existing abstractions and complete event payloads.
+Proceed with implementation. Deliver the shared reusable refresh foundation, domain-event invalidation, automatic ODM CRUD invalidation, repository fallback coverage for custom writes that bypass ODM observation, and Customer as the first adopter. Keep collection/reference full warmup and event-snapshot refresh as explicit follow-ups unless implementation reveals safe existing abstractions and complete event payloads.

--- a/specs/issue-176-async-cache-refresh/implementation-readiness.md
+++ b/specs/issue-176-async-cache-refresh/implementation-readiness.md
@@ -14,7 +14,7 @@ Ready to implement with scoped constraints.
 ## Gaps and Mitigations
 
 - Generic adopter contract needs to stay feature-neutral.
-  - Mitigation: `RefreshCacheCommand` uses context, family, target identifiers, strategy, and event metadata only; Customer-specific meaning stays in Customer factory/resolver/handler classes.
+  - Mitigation: `CacheRefreshCommand` uses context, family, target identifiers, strategy, and event metadata only; Customer-specific meaning stays in Customer factory/resolver/handler classes.
 - Generic collection cache warmup is not currently represented by a stable repository query object.
   - Mitigation: declare collection policy and continue invalidating collection tags; implement same-entity refresh for detail/email families in this PR.
 - Reference-data mutations do not appear to publish domain events.

--- a/specs/issue-176-async-cache-refresh/implementation-readiness.md
+++ b/specs/issue-176-async-cache-refresh/implementation-readiness.md
@@ -8,7 +8,7 @@ Ready to implement with scoped constraints.
 
 - The existing repository already has the core primitives: Redis tag-aware cache, cache key builder, cached repository decorator, SQS-backed Messenger event bus, LocalStack configuration, EMF metric infrastructure, and cache performance tests.
 - The issue can be delivered without API contract changes.
-- Tests can be deterministic by invoking scheduler/handler paths directly while keeping Messenger routing under unit/config coverage.
+- Tests can be deterministic by invoking command factory/handler paths directly while keeping Messenger routing under unit/config coverage.
 
 ## Gaps and Mitigations
 
@@ -22,16 +22,16 @@ Ready to implement with scoped constraints.
 ## Required Validation
 
 - Unit tests:
-  - policy registry
+  - policy DTO/factory/collection/resolver
   - jitter bounds
   - repository policy usage
-  - refresh scheduler
-  - refresh handler
+  - refresh command creation
+  - refresh command handler
   - updated subscribers
   - metrics
 - Integration tests:
   - event invalidation plus handler refresh repopulates detail/email caches
-  - scheduler failure does not break subscriber execution
+  - refresh command dispatch failure does not break subscriber execution
 - Performance/load evidence:
   - `make cache-performance-tests`
   - `make cache-performance-load-tests` if Docker/LocalStack services are available

--- a/specs/issue-176-async-cache-refresh/implementation-readiness.md
+++ b/specs/issue-176-async-cache-refresh/implementation-readiness.md
@@ -1,0 +1,43 @@
+# Implementation Readiness
+
+## Readiness Result
+
+Ready to implement with scoped constraints.
+
+## Strengths
+
+- The existing repository already has the core primitives: Redis tag-aware cache, cache key builder, cached repository decorator, SQS-backed Messenger event bus, LocalStack configuration, EMF metric infrastructure, and cache performance tests.
+- The issue can be delivered without API contract changes.
+- Tests can be deterministic by invoking scheduler/handler paths directly while keeping Messenger routing under unit/config coverage.
+
+## Gaps and Mitigations
+
+- Generic collection cache warmup is not currently represented by a stable repository query object.
+  - Mitigation: declare collection policy and continue invalidating collection tags; implement same-entity refresh for detail/email families in this PR.
+- Reference-data mutations do not appear to publish domain events.
+  - Mitigation: declare reference policy and document the gap; avoid speculative reference refresh triggers unless events are added.
+- Hit/miss/stale-served metrics may not be fully observable through Symfony cache APIs.
+  - Mitigation: emit miss metrics inside cache callbacks and success metrics after returned cache reads; stale-served can be declared and emitted only where detectable.
+
+## Required Validation
+
+- Unit tests:
+  - policy registry
+  - jitter bounds
+  - repository policy usage
+  - refresh scheduler
+  - refresh handler
+  - updated subscribers
+  - metrics
+- Integration tests:
+  - event invalidation plus handler refresh repopulates detail/email caches
+  - scheduler failure does not break subscriber execution
+- Performance/load evidence:
+  - `make cache-performance-tests`
+  - `make cache-performance-load-tests` if Docker/LocalStack services are available
+- Final validation:
+  - `make ci`
+
+## Decision
+
+Proceed with implementation. Keep collection/reference full warmup as explicit follow-up unless implementation reveals a safe existing abstraction.

--- a/specs/issue-176-async-cache-refresh/implementation-readiness.md
+++ b/specs/issue-176-async-cache-refresh/implementation-readiness.md
@@ -9,16 +9,24 @@ Ready to implement with scoped constraints.
 - The existing repository already has the core primitives: Redis tag-aware cache, cache key builder, cached repository decorator, SQS-backed Messenger event bus, LocalStack configuration, EMF metric infrastructure, and cache performance tests.
 - The issue can be delivered without API contract changes.
 - The reusable foundation can reuse existing class-type directories and deptrac-collected namespaces.
+- Automatic CRUD invalidation can use ODM UnitOfWork/change-set data, which avoids adding cache methods to Domain repository interfaces.
+- The ODM listener can handle old and new indexed values, so email-change invalidation can be generic and correct.
 - Tests can be deterministic by invoking the shared worker and Customer handler paths directly while keeping Messenger routing under unit/config coverage.
 
 ## Gaps and Mitigations
 
 - Generic adopter contract needs to stay feature-neutral.
-  - Mitigation: `CacheRefreshCommand` uses context, family, target identifiers, strategy, and event metadata only; Customer-specific meaning stays in Customer factory/resolver/handler classes.
+  - Mitigation: `CacheRefreshCommand` uses context, family, target identifiers, strategy, refresh source, and event metadata only; Customer-specific meaning stays in Customer factory/resolver/handler classes.
+- Automatic CRUD invalidation must not become Customer-specific.
+  - Mitigation: put the ODM listener in Shared Infrastructure and put Customer mapping in `CustomerCacheInvalidationRuleCollection` and `CustomerCacheInvalidationTagResolver`.
+- ODM lifecycle listeners may not observe direct bulk update/delete operations if they bypass UnitOfWork document change sets.
+  - Mitigation: document that implementation must use repository/DocumentManager paths that flush managed documents, and add explicit fallbacks only when tests identify a bypass.
 - Generic collection cache warmup is not currently represented by a stable repository query object.
   - Mitigation: declare collection policy and continue invalidating collection tags; implement same-entity refresh for detail/email families in this PR.
 - Reference-data mutations do not appear to publish domain events.
   - Mitigation: declare reference policy and document the gap; avoid speculative reference refresh triggers unless events are added.
+- Event-only cache refresh from current Customer events is unsafe because those events carry identifiers and emails, not complete Customer snapshots.
+  - Mitigation: use `repository_refresh` as the default. Reserve `event_snapshot` for future complete, versioned event payloads with stale-overwrite protection.
 - Hit/miss/stale-served metrics may not be fully observable through Symfony cache APIs.
   - Mitigation: emit miss metrics inside cache callbacks and success metrics after returned cache reads; stale-served can be declared and emitted only where detectable.
 
@@ -27,16 +35,22 @@ Ready to implement with scoped constraints.
 - Unit tests:
   - shared command serialization and scalar payload contract
   - shared worker delegation and failure isolation
+  - shared ODM invalidation listener insert/update/delete behavior
+  - invalidation rule and tag resolver behavior
   - shared abstract subscriber/factory/context handler behavior
   - policy DTO/factory/collection/resolver
+  - refresh source handling for `repository_refresh`, `event_snapshot`, and `invalidate_only`
   - jitter bounds
   - repository policy usage
   - Customer refresh command creation
+  - Customer invalidation rules and old/new email tag resolution
   - Customer refresh command handler
   - updated Customer subscribers
   - metrics
 - Integration tests:
-  - event invalidation plus shared worker and Customer handler refresh repopulates detail/email caches
+  - automatic CRUD invalidation plus shared worker and Customer handler refresh repopulates detail/email caches
+  - update with email change invalidates previous and current email lookup tags
+  - delete invalidates without warming deleted entities
   - refresh command dispatch failure does not break subscriber execution
 - Performance/load evidence:
   - `make cache-performance-tests`
@@ -46,4 +60,4 @@ Ready to implement with scoped constraints.
 
 ## Decision
 
-Proceed with implementation. Deliver the shared reusable refresh foundation and Customer as the first adopter. Keep collection/reference full warmup as explicit follow-up unless implementation reveals a safe existing abstraction.
+Proceed with implementation. Deliver the shared reusable refresh foundation, automatic ODM CRUD invalidation, and Customer as the first adopter. Keep collection/reference full warmup and event-snapshot refresh as explicit follow-ups unless implementation reveals safe existing abstractions and complete event payloads.

--- a/specs/issue-176-async-cache-refresh/prd.md
+++ b/specs/issue-176-async-cache-refresh/prd.md
@@ -2,12 +2,14 @@
 
 ## Objective
 
-Implement endpoint-grade cache consistency through a reusable domain-event-driven cache refresh pattern. Customer cached families are the first implementation scope, but the shared command payload, queue, worker, abstract subscriber, abstract factory, handler base, policy DTOs, and metrics must be reusable by future bounded contexts.
+Implement endpoint-grade cache consistency through reusable automatic CRUD invalidation plus async cache refresh. Customer cached families are the first implementation scope, but the shared ODM invalidation listener, command payload, queue, worker, abstract subscriber, abstract factory, handler base, policy DTOs, and metrics must be reusable by future bounded contexts.
 
 ## Functional Requirements
 
 1. Provide shared typed cache-refresh policy and target DTOs for cached query families across bounded contexts.
 2. Provide shared orchestration classes for:
+   - automatic CRUD cache invalidation from Doctrine MongoDB ODM flush/change-set data
+   - invalidation rule and tag-set DTOs
    - domain-event cache invalidation subscribers
    - cache refresh command factories
    - the generic refresh cache command
@@ -16,6 +18,8 @@ Implement endpoint-grade cache consistency through a reusable domain-event-drive
 3. Add a single shared cache-refresh Messenger transport backed by SQS in non-test environments and LocalStack locally.
 4. Keep the existing domain-event worker path intact so any domain event can trigger cache invalidation and refresh scheduling through tagged subscribers.
 5. Allow each bounded context to declare cache families and refresh adapters through existing class-type directories, including:
+   - invalidation rule collection
+   - invalidation tag resolver
    - policy collection
    - policy resolver
    - target resolver
@@ -28,10 +32,10 @@ Implement endpoint-grade cache consistency through a reusable domain-event-drive
    - customer reference-data policy declaration
    - negative lookup policy declaration
 7. Replace hardcoded Customer detail/email TTLs in `CachedCustomerRepository` with resolved cache-refresh policies.
-8. Update Customer create/update/delete cache subscribers so they:
-   - invalidate affected tags
-   - enqueue same-entity refresh workloads through the shared subscriber path
-   - never break business writes because refresh scheduling fails
+8. Add Customer automatic CRUD invalidation rules so create/update/delete writes:
+   - invalidate affected ID, email, old-email, and collection tags after successful ODM flush
+   - enqueue same-entity refresh workloads when the cache policy uses `repository_refresh`
+   - never break business writes because cache invalidation or refresh scheduling fails
 9. Add shared typed EMF metrics for:
    - cache refresh scheduled
    - cache refresh succeeded
@@ -40,6 +44,10 @@ Implement endpoint-grade cache consistency through a reusable domain-event-drive
    - cache miss
    - stale served where the implementation can detect it
 10. Document TTL defaults and justify them by data volatility and stale-read risk.
+11. Model refresh source explicitly:
+    - `repository_refresh` as the issue #176 default
+    - `event_snapshot` as a future option only for complete versioned event payloads
+    - `invalidate_only` for deletes and unsupported proactive warmup
 
 ## Non-Functional Requirements
 
@@ -48,24 +56,28 @@ Implement endpoint-grade cache consistency through a reusable domain-event-drive
 - SQS routing uses existing AWS/LocalStack environment conventions.
 - Implementation uses existing directory names and deptrac-collected class types.
 - No new bounded-context `Cache`, `ReadModel`, `Policy`, `Registry`, `Scheduler`, `Message`, or `MessageHandler` directories are introduced.
+- No cache invalidation methods are added to Domain repository interfaces.
 - Tests use Makefile targets or Docker container execution.
 - CI must pass without lowered thresholds.
 
 ## Acceptance Criteria Mapping
 
-- Reusable orchestration: shared abstract subscriber, abstract factory, generic `CacheRefreshCommand`, generic `CacheRefreshCommandHandler`, reusable context handler base, policy DTOs, target DTOs, resolvers, collections, and metrics exist with unit tests.
-- Domain-event invalidation plus async recalculation: existing domain-event worker invokes context subscribers, which schedule cache-refresh commands after invalidation.
+- Reusable orchestration: shared ODM invalidation listener, abstract subscriber, abstract factory, generic `CacheRefreshCommand`, generic `CacheRefreshCommandHandler`, reusable context handler base, policy DTOs, target DTOs, resolvers, collections, and metrics exist with unit tests.
+- Automatic CRUD invalidation: ODM create/update/delete flushes invalidate resolved cache tags after successful writes, including old and new indexed values where relevant.
+- Domain-event invalidation plus async recalculation: existing domain-event worker invokes context subscribers for event-driven refresh scheduling that is not fully covered by automatic CRUD invalidation.
 - Queue reuse: one shared `cache-refresh` transport and one `failed-cache-refresh` transport handle the generic refresh command for all contexts.
 - Customer first adapter: Customer detail and email lookup refresh through the shared orchestration; collection/reference policies are declared and tag-invalidated.
+- Refresh source: Customer uses `repository_refresh`; event-only cache refresh is documented as future-safe only when events carry complete, versioned snapshots.
 - LocalStack compatibility: `.env` and `config/packages/messenger.yaml` add cache refresh DSN/transport mirroring existing SQS conventions.
-- Writes do not block on rebuild: subscribers only schedule work; handlers run separately.
+- Writes do not block on rebuild: invalidation listeners and subscribers only schedule work; handlers run separately.
 - TTL defaults documented: docs update with policy table and rationale.
 - Observability: shared typed EMF metrics and tests.
-- Tests: unit coverage for shared orchestration, Customer adapter, policy resolution, command dispatch, handler behavior, subscribers, metrics, and integration coverage for post-event warmup.
+- Tests: unit coverage for shared orchestration, automatic invalidation, Customer adapter, policy resolution, command dispatch, handler behavior, subscribers, metrics, and integration coverage for post-write warmup.
 
 ## Out of Scope
 
 - New reference-data domain events.
+- Event-only cache refresh from current Customer events.
 - Full arbitrary collection result materialization for every API Platform filter combination.
 - Per-domain cache-refresh queues.
 - New infrastructure dashboards or CloudWatch alarms.

--- a/specs/issue-176-async-cache-refresh/prd.md
+++ b/specs/issue-176-async-cache-refresh/prd.md
@@ -2,21 +2,23 @@
 
 ## Objective
 
-Implement endpoint-grade cache consistency through reusable automatic CRUD invalidation plus async cache refresh. Customer cached families are the first implementation scope, but the shared ODM invalidation listener, command payload, queue, worker, abstract subscriber, abstract factory, handler base, policy DTOs, and metrics must be reusable by future bounded contexts.
+Implement endpoint-grade cache consistency through layered automatic invalidation plus async cache refresh. Customer cached families are the first implementation scope, but the shared invalidation command, ODM invalidation listener, domain-event subscribers, repository fallback path, refresh command payload, queue, worker, abstract factory, handler base, policy DTOs, and metrics must be reusable by future bounded contexts.
 
 ## Functional Requirements
 
 1. Provide shared typed cache-refresh policy and target DTOs for cached query families across bounded contexts.
 2. Provide shared orchestration classes for:
+   - a generic idempotent cache invalidation command and handler
    - automatic CRUD cache invalidation from Doctrine MongoDB ODM flush/change-set data
    - invalidation rule and tag-set DTOs
    - domain-event cache invalidation subscribers
+   - repository fallback invalidation for custom writes that bypass ODM change sets
    - cache refresh command factories
    - the generic refresh cache command
    - the generic refresh cache command worker
    - reusable context refresh command handler behavior
 3. Add a single shared cache-refresh Messenger transport backed by SQS in non-test environments and LocalStack locally.
-4. Keep the existing domain-event worker path intact so any domain event can trigger cache invalidation and refresh scheduling through tagged subscribers.
+4. Keep the existing domain-event worker path intact so any exposed domain event can automatically trigger cache invalidation and refresh scheduling through tagged subscribers.
 5. Allow each bounded context to declare cache families and refresh adapters through existing class-type directories, including:
    - invalidation rule collection
    - invalidation tag resolver
@@ -36,15 +38,14 @@ Implement endpoint-grade cache consistency through reusable automatic CRUD inval
    - invalidate affected ID, email, old-email, and collection tags after successful ODM flush
    - enqueue same-entity refresh workloads when the cache policy uses `repository_refresh`
    - never break business writes because cache invalidation or refresh scheduling fails
-9. Add shared typed EMF metrics for:
-   - cache refresh scheduled
-   - cache refresh succeeded
-   - cache refresh failed
-   - cache hit
-   - cache miss
-   - stale served where the implementation can detect it
-10. Document TTL defaults and justify them by data volatility and stale-read risk.
-11. Model refresh source explicitly:
+9. Review custom repository methods so:
+   - methods that persist/remove managed documents and flush are covered by the ODM listener
+   - methods that bypass ODM UnitOfWork change sets call the shared invalidation command after successful writes
+   - repository fallback invalidation remains outside Domain repository interfaces
+10. Add deterministic dedupe keys so domain-event, ODM, and repository-fallback invalidation signals can overlap without unbounded duplicate refresh jobs.
+11. Add shared typed EMF metrics for cache refresh scheduled, cache refresh succeeded, cache refresh failed, cache hit, cache miss, and stale served where the implementation can detect it.
+12. Document TTL defaults and justify them by data volatility and stale-read risk.
+13. Model refresh source explicitly:
     - `repository_refresh` as the issue #176 default
     - `event_snapshot` as a future option only for complete versioned event payloads
     - `invalidate_only` for deletes and unsupported proactive warmup
@@ -57,14 +58,17 @@ Implement endpoint-grade cache consistency through reusable automatic CRUD inval
 - Implementation uses existing directory names and deptrac-collected class types.
 - No new bounded-context `Cache`, `ReadModel`, `Policy`, `Registry`, `Scheduler`, `Message`, or `MessageHandler` directories are introduced.
 - No cache invalidation methods are added to Domain repository interfaces.
+- Direct writes outside this service cannot be detected automatically; they must expose an integration/domain event or invoke an operational cache-clear command.
 - Tests use Makefile targets or Docker container execution.
 - CI must pass without lowered thresholds.
 
 ## Acceptance Criteria Mapping
 
-- Reusable orchestration: shared ODM invalidation listener, abstract subscriber, abstract factory, generic `CacheRefreshCommand`, generic `CacheRefreshCommandHandler`, reusable context handler base, policy DTOs, target DTOs, resolvers, collections, and metrics exist with unit tests.
+- Reusable orchestration: shared invalidation command/handler, ODM invalidation listener, abstract subscriber, abstract factory, generic `CacheRefreshCommand`, generic `CacheRefreshCommandHandler`, reusable context handler base, policy DTOs, target DTOs, resolvers, collections, and metrics exist with unit tests.
 - Automatic CRUD invalidation: ODM create/update/delete flushes invalidate resolved cache tags after successful writes, including old and new indexed values where relevant.
-- Domain-event invalidation plus async recalculation: existing domain-event worker invokes context subscribers for event-driven refresh scheduling that is not fully covered by automatic CRUD invalidation.
+- Domain-event invalidation plus async recalculation: existing domain-event worker invokes context subscribers for every exposed event that declares cache impact, independent of ODM invalidation.
+- Custom repository fallback: write paths that bypass ODM change-set observation call the shared invalidation command after successful write completion.
+- Dedupe: duplicate invalidation signals from domain events, ODM changes, and repository fallback paths are idempotent and do not produce unbounded duplicate refresh jobs.
 - Queue reuse: one shared `cache-refresh` transport and one `failed-cache-refresh` transport handle the generic refresh command for all contexts.
 - Customer first adapter: Customer detail and email lookup refresh through the shared orchestration; collection/reference policies are declared and tag-invalidated.
 - Refresh source: Customer uses `repository_refresh`; event-only cache refresh is documented as future-safe only when events carry complete, versioned snapshots.
@@ -76,7 +80,7 @@ Implement endpoint-grade cache consistency through reusable automatic CRUD inval
 
 ## Out of Scope
 
-- New reference-data domain events.
+- New reference-data domain events, because ODM listener rules can cover managed reference document invalidation for this issue.
 - Event-only cache refresh from current Customer events.
 - Full arbitrary collection result materialization for every API Platform filter combination.
 - Per-domain cache-refresh queues.

--- a/specs/issue-176-async-cache-refresh/prd.md
+++ b/specs/issue-176-async-cache-refresh/prd.md
@@ -1,66 +1,75 @@
-# PRD: Async Endpoint Cache Refresh
+# PRD: Abstract Async Endpoint Cache Refresh
 
 ## Objective
 
-Implement endpoint-grade cache consistency for customer cached query families so writes remain fast, stale reads are bounded by declared policy, and affected cache entries can be warmed by background workers instead of the next user request.
+Implement endpoint-grade cache consistency through a reusable domain-event-driven cache refresh pattern. Customer cached families are the first implementation scope, but the shared command payload, queue, worker, abstract subscriber, abstract factory, handler base, policy DTOs, and metrics must be reusable by future bounded contexts.
 
 ## Functional Requirements
 
-1. Provide typed customer cache policies for cached query families:
+1. Provide shared typed cache-refresh policy and target DTOs for cached query families across bounded contexts.
+2. Provide shared orchestration classes for:
+   - domain-event cache invalidation subscribers
+   - cache refresh command factories
+   - the generic refresh cache command
+   - the generic refresh cache command worker
+   - reusable context refresh command handler behavior
+3. Add a single shared cache-refresh Messenger transport backed by SQS in non-test environments and LocalStack locally.
+4. Keep the existing domain-event worker path intact so any domain event can trigger cache invalidation and refresh scheduling through tagged subscribers.
+5. Allow each bounded context to declare cache families and refresh adapters through existing class-type directories, including:
+   - policy collection
+   - policy resolver
+   - target resolver
+   - cached repository decorator
+   - concrete context refresh command handler
+6. Implement Customer as the first adapter for:
    - customer detail by ID
    - customer lookup by email
-   - customer collection/search
-   - customer reference data
-   - negative lookup cache
-2. Each policy must expose:
-   - family identifier
-   - key namespace
-   - base tags
-   - soft TTL
-   - hard TTL
-   - jitter
-   - consistency class
-   - refresh strategy
-3. Replace hardcoded customer detail/email TTLs in `CachedCustomerRepository` with resolved cache policies.
-4. Split cache pools by customer query family in Symfony cache configuration, while preserving a compatibility alias if existing tests or fixtures still use `cache.customer`.
-5. Add `RefreshCustomerCacheCommand` routed through Symfony Messenger to an SQS-backed transport in non-test environments.
-6. Add a command handler that refreshes same-entity customer detail and email lookup entries from the inner repository.
-7. Update customer create/update/delete cache subscribers so they:
+   - customer collection/search policy declaration
+   - customer reference-data policy declaration
+   - negative lookup policy declaration
+7. Replace hardcoded Customer detail/email TTLs in `CachedCustomerRepository` with resolved cache-refresh policies.
+8. Update Customer create/update/delete cache subscribers so they:
    - invalidate affected tags
-   - enqueue same-entity refresh workloads for affected customer detail/email families when useful
+   - enqueue same-entity refresh workloads through the shared subscriber path
    - never break business writes because refresh scheduling fails
-8. Add typed EMF metrics for:
+9. Add shared typed EMF metrics for:
    - cache refresh scheduled
    - cache refresh succeeded
    - cache refresh failed
    - cache hit
    - cache miss
    - stale served where the implementation can detect it
-9. Document TTL defaults and justify them by CRM data volatility and stale-read risk.
+10. Document TTL defaults and justify them by data volatility and stale-read risk.
 
 ## Non-Functional Requirements
 
 - Domain layer remains framework-free.
-- Cache and metric failures are best effort.
+- Cache, queue, and metric failures are best effort.
 - SQS routing uses existing AWS/LocalStack environment conventions.
+- Implementation uses existing directory names and deptrac-collected class types.
+- No new bounded-context `Cache`, `ReadModel`, `Policy`, `Registry`, `Scheduler`, `Message`, or `MessageHandler` directories are introduced.
 - Tests use Makefile targets or Docker container execution.
 - CI must pass without lowered thresholds.
 
 ## Acceptance Criteria Mapping
 
-- Declared policy per cached family: policy DTO/factory/collection/resolver and unit tests.
-- Domain-event invalidation plus async recalculation: updated subscribers, refresh command/handler, Messenger routing.
-- LocalStack compatibility: `.env` and `config/packages/messenger.yaml` add cache refresh DSN/transport mirroring domain events.
-- Writes do not block on rebuild: subscribers only schedule work; handler runs separately.
+- Reusable orchestration: shared abstract subscriber, abstract factory, generic `RefreshCacheCommand`, generic `RefreshCacheCommandHandler`, reusable context handler base, policy DTOs, target DTOs, resolvers, collections, and metrics exist with unit tests.
+- Domain-event invalidation plus async recalculation: existing domain-event worker invokes context subscribers, which schedule cache-refresh commands after invalidation.
+- Queue reuse: one shared `cache-refresh` transport and one `failed-cache-refresh` transport handle the generic refresh command for all contexts.
+- Customer first adapter: Customer detail and email lookup refresh through the shared orchestration; collection/reference policies are declared and tag-invalidated.
+- LocalStack compatibility: `.env` and `config/packages/messenger.yaml` add cache refresh DSN/transport mirroring existing SQS conventions.
+- Writes do not block on rebuild: subscribers only schedule work; handlers run separately.
 - TTL defaults documented: docs update with policy table and rationale.
-- Observability: typed EMF metrics and tests.
-- Tests: unit coverage for policies, command dispatch, command handler, subscribers, metrics, integration coverage for post-event warmup, cache performance target rerun.
+- Observability: shared typed EMF metrics and tests.
+- Tests: unit coverage for shared orchestration, Customer adapter, policy resolution, command dispatch, handler behavior, subscribers, metrics, and integration coverage for post-event warmup.
 
 ## Out of Scope
 
 - New reference-data domain events.
 - Full arbitrary collection result materialization for every API Platform filter combination.
+- Per-domain cache-refresh queues.
 - New infrastructure dashboards or CloudWatch alarms.
+- Introducing read models or projections for issue #176.
 
 ## Release Notes
 

--- a/specs/issue-176-async-cache-refresh/prd.md
+++ b/specs/issue-176-async-cache-refresh/prd.md
@@ -1,0 +1,67 @@
+# PRD: Async Endpoint Cache Refresh
+
+## Objective
+
+Implement endpoint-grade cache consistency for customer cached query families so writes remain fast, stale reads are bounded by declared policy, and affected cache entries can be warmed by background workers instead of the next user request.
+
+## Functional Requirements
+
+1. Provide a typed cache policy registry for customer cached query families:
+   - customer detail by ID
+   - customer lookup by email
+   - customer collection/search
+   - customer reference data
+   - negative lookup cache
+2. Each policy must expose:
+   - family identifier
+   - key namespace
+   - base tags
+   - soft TTL
+   - hard TTL
+   - jitter
+   - consistency class
+   - refresh strategy
+3. Replace hardcoded customer detail/email TTLs in `CachedCustomerRepository` with registry policies.
+4. Split cache pools by customer query family in Symfony cache configuration, while preserving a compatibility alias if existing tests or fixtures still use `cache.customer`.
+5. Add a dedicated cache refresh message routed through Symfony Messenger to an SQS-backed transport in non-test environments.
+6. Add a cache refresh handler that refreshes same-entity customer detail and email lookup entries from the inner repository.
+7. Update customer create/update/delete cache subscribers so they:
+   - invalidate affected tags
+   - enqueue same-entity refresh workloads for affected customer detail/email families when useful
+   - never break business writes because refresh scheduling fails
+8. Add typed EMF metrics for:
+   - cache refresh scheduled
+   - cache refresh succeeded
+   - cache refresh failed
+   - cache hit
+   - cache miss
+   - stale served where the implementation can detect it
+9. Document TTL defaults and justify them by CRM data volatility and stale-read risk.
+
+## Non-Functional Requirements
+
+- Domain layer remains framework-free.
+- Cache and metric failures are best effort.
+- SQS routing uses existing AWS/LocalStack environment conventions.
+- Tests use Makefile targets or Docker container execution.
+- CI must pass without lowered thresholds.
+
+## Acceptance Criteria Mapping
+
+- Declared policy per cached family: policy registry and unit tests.
+- Domain-event invalidation plus async recalculation: updated subscribers, refresh scheduler/message/handler, Messenger routing.
+- LocalStack compatibility: `.env` and `config/packages/messenger.yaml` add cache refresh DSN/transport mirroring domain events.
+- Writes do not block on rebuild: subscribers only schedule work; handler runs separately.
+- TTL defaults documented: docs update with policy table and rationale.
+- Observability: typed EMF metrics and tests.
+- Tests: unit coverage for policies/scheduler/handler/subscribers/metrics, integration coverage for post-event warmup, cache performance target rerun.
+
+## Out of Scope
+
+- New reference-data domain events.
+- Full arbitrary collection result materialization for every API Platform filter combination.
+- New infrastructure dashboards or CloudWatch alarms.
+
+## Release Notes
+
+This is a backwards-compatible internal behavior change. Existing API contracts remain unchanged.

--- a/specs/issue-176-async-cache-refresh/prd.md
+++ b/specs/issue-176-async-cache-refresh/prd.md
@@ -6,7 +6,7 @@ Implement endpoint-grade cache consistency for customer cached query families so
 
 ## Functional Requirements
 
-1. Provide a typed cache policy registry for customer cached query families:
+1. Provide typed customer cache policies for cached query families:
    - customer detail by ID
    - customer lookup by email
    - customer collection/search
@@ -21,10 +21,10 @@ Implement endpoint-grade cache consistency for customer cached query families so
    - jitter
    - consistency class
    - refresh strategy
-3. Replace hardcoded customer detail/email TTLs in `CachedCustomerRepository` with registry policies.
+3. Replace hardcoded customer detail/email TTLs in `CachedCustomerRepository` with resolved cache policies.
 4. Split cache pools by customer query family in Symfony cache configuration, while preserving a compatibility alias if existing tests or fixtures still use `cache.customer`.
-5. Add a dedicated cache refresh message routed through Symfony Messenger to an SQS-backed transport in non-test environments.
-6. Add a cache refresh handler that refreshes same-entity customer detail and email lookup entries from the inner repository.
+5. Add `RefreshCustomerCacheCommand` routed through Symfony Messenger to an SQS-backed transport in non-test environments.
+6. Add a command handler that refreshes same-entity customer detail and email lookup entries from the inner repository.
 7. Update customer create/update/delete cache subscribers so they:
    - invalidate affected tags
    - enqueue same-entity refresh workloads for affected customer detail/email families when useful
@@ -48,13 +48,13 @@ Implement endpoint-grade cache consistency for customer cached query families so
 
 ## Acceptance Criteria Mapping
 
-- Declared policy per cached family: policy registry and unit tests.
-- Domain-event invalidation plus async recalculation: updated subscribers, refresh scheduler/message/handler, Messenger routing.
+- Declared policy per cached family: policy DTO/factory/collection/resolver and unit tests.
+- Domain-event invalidation plus async recalculation: updated subscribers, refresh command/handler, Messenger routing.
 - LocalStack compatibility: `.env` and `config/packages/messenger.yaml` add cache refresh DSN/transport mirroring domain events.
 - Writes do not block on rebuild: subscribers only schedule work; handler runs separately.
 - TTL defaults documented: docs update with policy table and rationale.
 - Observability: typed EMF metrics and tests.
-- Tests: unit coverage for policies/scheduler/handler/subscribers/metrics, integration coverage for post-event warmup, cache performance target rerun.
+- Tests: unit coverage for policies, command dispatch, command handler, subscribers, metrics, integration coverage for post-event warmup, cache performance target rerun.
 
 ## Out of Scope
 

--- a/specs/issue-176-async-cache-refresh/prd.md
+++ b/specs/issue-176-async-cache-refresh/prd.md
@@ -53,7 +53,7 @@ Implement endpoint-grade cache consistency through a reusable domain-event-drive
 
 ## Acceptance Criteria Mapping
 
-- Reusable orchestration: shared abstract subscriber, abstract factory, generic `RefreshCacheCommand`, generic `RefreshCacheCommandHandler`, reusable context handler base, policy DTOs, target DTOs, resolvers, collections, and metrics exist with unit tests.
+- Reusable orchestration: shared abstract subscriber, abstract factory, generic `CacheRefreshCommand`, generic `CacheRefreshCommandHandler`, reusable context handler base, policy DTOs, target DTOs, resolvers, collections, and metrics exist with unit tests.
 - Domain-event invalidation plus async recalculation: existing domain-event worker invokes context subscribers, which schedule cache-refresh commands after invalidation.
 - Queue reuse: one shared `cache-refresh` transport and one `failed-cache-refresh` transport handle the generic refresh command for all contexts.
 - Customer first adapter: Customer detail and email lookup refresh through the shared orchestration; collection/reference policies are declared and tag-invalidated.

--- a/specs/issue-176-async-cache-refresh/product-brief-distillate.md
+++ b/specs/issue-176-async-cache-refresh/product-brief-distillate.md
@@ -3,10 +3,13 @@
 Implement issue #176 as a reusable cache consistency platform:
 
 - shared cache-refresh DTOs, abstract subscribers, abstract commands, abstract handlers, factories, resolvers, collections, and metrics
+- shared automatic CRUD invalidation through an ODM listener plus typed rule/tag resolvers
 - one shared `cache-refresh` SQS worker path for any bounded context, plus `failed-cache-refresh`
 - existing domain-event workers continue to read any domain event and invoke context subscribers
 - Customer becomes the first adapter, not the only design target
-- Customer detail and email lookup get proactive async refresh first
+- Customer detail and email lookup get proactive async refresh first through `repository_refresh`
 - collection and reference policies are declared and tag-invalidated, with proactive arbitrary collection warmup deferred until a deterministic query abstraction exists
+- event-snapshot refresh is deferred until events carry complete, versioned cache payloads
+- no cache invalidation methods are added to Domain repository interfaces
 - no new context `Cache`, `ReadModel`, `Policy`, `Registry`, `Scheduler`, `Message`, or `MessageHandler` directories
 - tests, docs, and cache performance evidence complete the implementation PR

--- a/specs/issue-176-async-cache-refresh/product-brief-distillate.md
+++ b/specs/issue-176-async-cache-refresh/product-brief-distillate.md
@@ -3,7 +3,8 @@
 Implement issue #176 as a reusable cache consistency platform:
 
 - shared cache-refresh DTOs, abstract subscribers, abstract commands, abstract handlers, factories, resolvers, collections, and metrics
-- shared automatic CRUD invalidation through an ODM listener plus typed rule/tag resolvers
+- shared layered invalidation through domain events, an ODM listener, and repository fallback hooks for custom writes that bypass ODM observation
+- one idempotent invalidation command/handler used by every invalidation source
 - one shared `cache-refresh` SQS worker path for any bounded context, plus `failed-cache-refresh`
 - existing domain-event workers continue to read any domain event and invoke context subscribers
 - Customer becomes the first adapter, not the only design target

--- a/specs/issue-176-async-cache-refresh/product-brief-distillate.md
+++ b/specs/issue-176-async-cache-refresh/product-brief-distillate.md
@@ -2,9 +2,9 @@
 
 Implement issue #176 as a narrowly scoped cache consistency upgrade:
 
-- central typed cache policy registry
+- central typed cache policy DTO/factory/collection/resolver classes
 - split customer cache pools by query family
-- async cache refresh message/handler routed through SQS in non-test envs, with LocalStack for local/test
+- async cache refresh command/handler routed through SQS in non-test envs, with LocalStack for local/test
 - event subscribers invalidate tags and enqueue refresh work
 - typed EMF metrics for refresh/read cache lifecycle
 - tests and cache performance evidence

--- a/specs/issue-176-async-cache-refresh/product-brief-distillate.md
+++ b/specs/issue-176-async-cache-refresh/product-brief-distillate.md
@@ -1,0 +1,12 @@
+# Product Brief Distillate
+
+Implement issue #176 as a narrowly scoped cache consistency upgrade:
+
+- central typed cache policy registry
+- split customer cache pools by query family
+- async cache refresh message/handler routed through SQS in non-test envs, with LocalStack for local/test
+- event subscribers invalidate tags and enqueue refresh work
+- typed EMF metrics for refresh/read cache lifecycle
+- tests and cache performance evidence
+
+Primary delivery target: currently cached customer detail and email lookup families. Declare collection and reference policies now, but avoid speculative arbitrary collection warmup unless a deterministic query abstraction exists.

--- a/specs/issue-176-async-cache-refresh/product-brief-distillate.md
+++ b/specs/issue-176-async-cache-refresh/product-brief-distillate.md
@@ -1,12 +1,12 @@
 # Product Brief Distillate
 
-Implement issue #176 as a narrowly scoped cache consistency upgrade:
+Implement issue #176 as a reusable cache consistency platform:
 
-- central typed cache policy DTO/factory/collection/resolver classes
-- split customer cache pools by query family
-- async cache refresh command/handler routed through SQS in non-test envs, with LocalStack for local/test
-- event subscribers invalidate tags and enqueue refresh work
-- typed EMF metrics for refresh/read cache lifecycle
-- tests and cache performance evidence
-
-Primary delivery target: currently cached customer detail and email lookup families. Declare collection and reference policies now, but avoid speculative arbitrary collection warmup unless a deterministic query abstraction exists.
+- shared cache-refresh DTOs, abstract subscribers, abstract commands, abstract handlers, factories, resolvers, collections, and metrics
+- one shared `cache-refresh` SQS worker path for any bounded context, plus `failed-cache-refresh`
+- existing domain-event workers continue to read any domain event and invoke context subscribers
+- Customer becomes the first adapter, not the only design target
+- Customer detail and email lookup get proactive async refresh first
+- collection and reference policies are declared and tag-invalidated, with proactive arbitrary collection warmup deferred until a deterministic query abstraction exists
+- no new context `Cache`, `ReadModel`, `Policy`, `Registry`, `Scheduler`, `Message`, or `MessageHandler` directories
+- tests, docs, and cache performance evidence complete the implementation PR

--- a/specs/issue-176-async-cache-refresh/product-brief.md
+++ b/specs/issue-176-async-cache-refresh/product-brief.md
@@ -1,0 +1,66 @@
+# Product Brief: Async Endpoint Cache Refresh
+
+## Problem
+
+Customer reads are cached, but cache consistency is still request-path driven. Domain events invalidate cache tags, and the next user read may pay the cost to rebuild the affected cache entry. Cache policy is also spread across repository methods and Symfony cache pool defaults instead of being declared per endpoint/query family.
+
+This creates three product risks:
+
+- Write endpoints stay available, but related read endpoints can go cold after every write.
+- TTL choices are hardcoded and hard to justify or tune by data volatility.
+- Operators cannot see enough cache refresh lifecycle signals to tell whether async consistency is healthy.
+
+## Stakeholders
+
+- API consumers who expect customer reads to become fresh shortly after writes.
+- Operators who need visibility into cache refresh scheduling, success, failure, and stale reads.
+- Developers who need a clear cache policy contract for every cached customer query family.
+
+## Goals
+
+- Declare cache policy centrally for every customer cached endpoint/query family.
+- Split customer cache behavior by family: detail, lookup, collection, and reference data.
+- Keep business writes fast by invalidating cache and scheduling refresh work asynchronously.
+- Route refresh work through Symfony Messenger using SQS in non-test environments and LocalStack for local/test parity.
+- Emit typed EMF metrics for cache refresh lifecycle and cache read behavior.
+- Add unit/integration/load evidence for invalidation, async refresh, TTL jitter, and post-write cache freshness.
+
+## Non-Goals
+
+- Do not introduce a new external queue technology.
+- Do not move Domain entities or repositories into framework-dependent code.
+- Do not implement arbitrary API Platform collection materialization beyond stable query shapes. A stable query shape has a deterministic key and parameter set, such as a customer list filtered by status; arbitrary materialization means warming ad-hoc API Platform filter combinations without a repository query contract. See [architecture.md](architecture.md) for the collection caching strategy.
+- Do not block writes on refresh success.
+- Do not lower quality, coverage, mutation, architecture, or style thresholds.
+
+## Success Metrics
+
+- All currently cached customer query families use declared policy objects instead of hardcoded TTL constants.
+- Domain events enqueue refresh work after invalidation.
+- Cache refresh handler warms affected customer detail and email lookup entries without a user request.
+- Refresh failures are logged and measured but do not fail domain-event processing.
+- Local and CI Messenger routing works with in-memory test transport, SQS runtime transport, and LocalStack-backed local transport.
+- `make ci` passes.
+- Cache performance smoke evidence is captured with `make cache-performance-tests` and `make cache-performance-load-tests` where runtime services allow.
+
+## Key Requirements
+
+- Add typed cache policy registry with namespace, tags, soft TTL, hard TTL, jitter, consistency class, and refresh strategy.
+- Use environment-overridable TTL/jitter parameters in Symfony service config.
+- Add dedicated cache refresh message and Messenger handler.
+- Update customer cache invalidation subscribers to invalidate and schedule same-entity refresh workloads.
+- Add typed metrics for refresh scheduled, success, failure, stale served, hit, and miss.
+- Keep cache and metric failures best effort.
+- Update documentation for TTL defaults and operations.
+
+## Assumptions
+
+- First implementation focuses background refresh on currently cached customer detail and email lookup entries.
+- Same-entity refresh workloads mean refresh jobs for the specific cache keys affected by the domain event, such as customer detail by ID and lookup by email. They do not include arbitrary collection query refreshes.
+- Collection and reference-data policies are declared and tags are invalidated immediately. Async refresh for collections remains a follow-up unless a deterministic query-shape abstraction exists; until then, collection entries stay request-path cached after invalidation instead of being warmed proactively.
+- Integration tests can invoke the refresh handler directly for deterministic proof while unit tests cover Messenger routing and scheduler dispatch.
+
+## Open Questions
+
+- Should customer type/status create/update/delete operations publish domain events in a follow-up so reference-data refresh can be fully event-driven?
+- Should collection endpoint caching be implemented through an API Platform provider decorator in a later issue?

--- a/specs/issue-176-async-cache-refresh/product-brief.md
+++ b/specs/issue-176-async-cache-refresh/product-brief.md
@@ -55,7 +55,7 @@ This creates three product risks:
 ## Key Requirements
 
 - Add shared cache-refresh DTOs with context, family, target identifiers, strategy, and event metadata.
-- Add a generic `RefreshCacheCommand` and shared `RefreshCacheCommandHandler`.
+- Add a generic `CacheRefreshCommand` and shared `CacheRefreshCommandHandler`.
 - Add abstract subscriber, factory, and context handler classes so bounded contexts only implement event mapping and warmup logic.
 - Add Customer policy collection/resolver/target resolver/handler adapters through existing directories.
 - Update Customer cache invalidation subscribers to invalidate and schedule same-entity refresh workloads through the shared path.

--- a/specs/issue-176-async-cache-refresh/product-brief.md
+++ b/specs/issue-176-async-cache-refresh/product-brief.md
@@ -4,6 +4,8 @@
 
 Customer reads are cached, but cache consistency is still request-path driven. Domain events invalidate cache tags, and the next user read may pay the cost to rebuild the affected cache entry. Cache policy is also spread across repository methods and Symfony cache pool defaults instead of being declared per endpoint/query family.
 
+The current domain events identify affected cache entries, but they do not carry complete Customer snapshots. Rebuilding cache entries directly from those events would couple correctness to incomplete payloads. The safer shared design is automatic CRUD invalidation from ODM write/change-set data plus async refresh from persisted state.
+
 Solving this only with Customer-specific commands and workers would create a second product risk: every future bounded context would need to copy the same refresh queue, worker, metrics, and failure behavior.
 
 This creates three product risks:
@@ -23,6 +25,7 @@ This creates three product risks:
 ## Goals
 
 - Add one reusable cache refresh orchestration that can be adopted by any bounded context.
+- Add one reusable automatic CRUD invalidation path that can invalidate cache tags for any mapped ODM document.
 - Keep the existing domain-event worker as the ingress for any domain event.
 - Add one generic refresh command payload, one shared `cache-refresh` queue, and one shared worker.
 - Keep context-specific mapping in bounded-context adapters.
@@ -38,15 +41,18 @@ This creates three product risks:
 - Do not implement arbitrary API Platform collection materialization beyond stable query shapes. A stable query shape has a deterministic key and parameter set, such as a customer list filtered by status; arbitrary materialization means warming ad-hoc API Platform filter combinations without a repository query contract. See [architecture.md](architecture.md) for the collection caching strategy.
 - Do not block writes on refresh success.
 - Do not create per-domain cache-refresh queues in the first implementation.
+- Do not add cache invalidation methods to Domain repository interfaces.
+- Do not use event-only cache refresh for Customer until events carry complete, versioned cache snapshots.
 - Do not introduce `ReadModel`, `Message`, `MessageHandler`, `Scheduler`, `Registry`, `Policy`, or context-level `Cache` directories.
 - Do not lower quality, coverage, mutation, architecture, or style thresholds.
 
 ## Success Metrics
 
 - One shared refresh command, queue, and worker path can refresh cache entries for any registered bounded-context adapter.
+- One shared ODM listener can invalidate mapped cache tags after successful create/update/delete flushes.
 - Customer adopts the shared path for currently cached detail and email lookup families.
 - Hardcoded Customer detail/email TTLs are replaced by resolved policy objects.
-- Domain events enqueue refresh work after invalidation without blocking writes.
+- Automatic CRUD invalidation and domain events enqueue refresh work after invalidation without blocking writes.
 - Refresh failures are logged and measured but do not fail domain-event processing.
 - Local and CI Messenger routing works with in-memory test transport, SQS runtime transport, and LocalStack-backed local transport.
 - `make ci` passes.
@@ -55,10 +61,13 @@ This creates three product risks:
 ## Key Requirements
 
 - Add shared cache-refresh DTOs with context, family, target identifiers, strategy, and event metadata.
+- Add shared invalidation DTOs/resolvers/collections for document-class, operation, and change-set driven tag resolution.
+- Add a shared Doctrine MongoDB ODM invalidation listener that invalidates after successful flush and can schedule `repository_refresh` work.
 - Add a generic `CacheRefreshCommand` and shared `CacheRefreshCommandHandler`.
 - Add abstract subscriber, factory, and context handler classes so bounded contexts only implement event mapping and warmup logic.
 - Add Customer policy collection/resolver/target resolver/handler adapters through existing directories.
-- Update Customer cache invalidation subscribers to invalidate and schedule same-entity refresh workloads through the shared path.
+- Add Customer invalidation rule/tag adapters through existing Infrastructure collection/resolver directories.
+- Keep Customer cache invalidation subscribers narrow, using them only where domain-event scheduling is still needed beyond automatic CRUD invalidation.
 - Use environment-overridable TTL/jitter parameters in Symfony service config.
 - Add shared typed metrics for refresh scheduled, success, failure, stale served, hit, and miss.
 - Keep cache, queue, and metric failures best effort.
@@ -67,7 +76,9 @@ This creates three product risks:
 ## Assumptions
 
 - First implementation focuses background refresh on currently cached Customer detail and email lookup entries.
-- Same-entity refresh workloads mean refresh jobs for the specific cache keys affected by the domain event, such as Customer detail by ID and lookup by email. They do not include arbitrary collection query refreshes.
+- Same-entity refresh workloads mean refresh jobs for the specific cache keys affected by the write or domain event, such as Customer detail by ID and lookup by email. They do not include arbitrary collection query refreshes.
+- Detail and email lookup refresh use `repository_refresh`, meaning the worker reloads current persisted state through a context adapter.
+- `event_snapshot` remains a future refresh source for events that carry complete, versioned, serialization-stable cache payloads.
 - Collection and reference-data policies are declared and tags are invalidated immediately. Async refresh for collections remains a follow-up unless a deterministic query-shape abstraction exists; until then, collection entries stay request-path cached after invalidation instead of being warmed proactively.
 - Integration tests can invoke the shared worker and Customer handler directly for deterministic proof while unit tests cover Messenger routing and command dispatch.
 
@@ -75,3 +86,4 @@ This creates three product risks:
 
 - Should Customer type/status create/update/delete operations publish domain events in a follow-up so reference-data refresh can be fully event-driven?
 - Should collection endpoint caching be implemented through an API Platform provider decorator in a later issue?
+- Are there any production write paths that bypass ODM UnitOfWork change sets and need explicit repository-level invalidation fallback?

--- a/specs/issue-176-async-cache-refresh/product-brief.md
+++ b/specs/issue-176-async-cache-refresh/product-brief.md
@@ -37,7 +37,7 @@ This creates three product risks:
 
 - All currently cached customer query families use declared policy objects instead of hardcoded TTL constants.
 - Domain events enqueue refresh work after invalidation.
-- Cache refresh handler warms affected customer detail and email lookup entries without a user request.
+- Cache refresh command handler warms affected customer detail and email lookup entries without a user request.
 - Refresh failures are logged and measured but do not fail domain-event processing.
 - Local and CI Messenger routing works with in-memory test transport, SQS runtime transport, and LocalStack-backed local transport.
 - `make ci` passes.
@@ -45,9 +45,9 @@ This creates three product risks:
 
 ## Key Requirements
 
-- Add typed cache policy registry with namespace, tags, soft TTL, hard TTL, jitter, consistency class, and refresh strategy.
+- Add typed cache policy DTO/factory/collection/resolver classes with namespace, tags, soft TTL, hard TTL, jitter, consistency class, and refresh strategy.
 - Use environment-overridable TTL/jitter parameters in Symfony service config.
-- Add dedicated cache refresh message and Messenger handler.
+- Add dedicated `RefreshCustomerCacheCommand` and command handler routed through Messenger.
 - Update customer cache invalidation subscribers to invalidate and schedule same-entity refresh workloads.
 - Add typed metrics for refresh scheduled, success, failure, stale served, hit, and miss.
 - Keep cache and metric failures best effort.
@@ -58,7 +58,7 @@ This creates three product risks:
 - First implementation focuses background refresh on currently cached customer detail and email lookup entries.
 - Same-entity refresh workloads mean refresh jobs for the specific cache keys affected by the domain event, such as customer detail by ID and lookup by email. They do not include arbitrary collection query refreshes.
 - Collection and reference-data policies are declared and tags are invalidated immediately. Async refresh for collections remains a follow-up unless a deterministic query-shape abstraction exists; until then, collection entries stay request-path cached after invalidation instead of being warmed proactively.
-- Integration tests can invoke the refresh handler directly for deterministic proof while unit tests cover Messenger routing and scheduler dispatch.
+- Integration tests can invoke the command handler directly for deterministic proof while unit tests cover Messenger routing and command dispatch.
 
 ## Open Questions
 

--- a/specs/issue-176-async-cache-refresh/product-brief.md
+++ b/specs/issue-176-async-cache-refresh/product-brief.md
@@ -4,7 +4,7 @@
 
 Customer reads are cached, but cache consistency is still request-path driven. Domain events invalidate cache tags, and the next user read may pay the cost to rebuild the affected cache entry. Cache policy is also spread across repository methods and Symfony cache pool defaults instead of being declared per endpoint/query family.
 
-The current domain events identify affected cache entries, but they do not carry complete Customer snapshots. Rebuilding cache entries directly from those events would couple correctness to incomplete payloads. The safer shared design is automatic CRUD invalidation from ODM write/change-set data plus async refresh from persisted state.
+The current domain events identify affected cache entries, but they do not carry complete Customer snapshots. Rebuilding cache entries directly from those events would couple correctness to incomplete payloads. The safer shared design is layered automatic invalidation: domain events clear cache when exposed, ODM change sets clear cache when managed documents change, and custom repository fallbacks clear cache when a write bypasses ODM observation.
 
 Solving this only with Customer-specific commands and workers would create a second product risk: every future bounded context would need to copy the same refresh queue, worker, metrics, and failure behavior.
 
@@ -27,6 +27,7 @@ This creates three product risks:
 - Add one reusable cache refresh orchestration that can be adopted by any bounded context.
 - Add one reusable automatic CRUD invalidation path that can invalidate cache tags for any mapped ODM document.
 - Keep the existing domain-event worker as the ingress for any domain event.
+- Add repository fallback invalidation for custom write methods that cannot be observed by ODM UnitOfWork change sets.
 - Add one generic refresh command payload, one shared `cache-refresh` queue, and one shared worker.
 - Keep context-specific mapping in bounded-context adapters.
 - Implement Customer detail and email lookup refresh as the first adoption.
@@ -50,6 +51,8 @@ This creates three product risks:
 
 - One shared refresh command, queue, and worker path can refresh cache entries for any registered bounded-context adapter.
 - One shared ODM listener can invalidate mapped cache tags after successful create/update/delete flushes.
+- One shared domain-event subscriber path invalidates mapped cache tags when domain events are exposed.
+- Custom repository methods are classified as ODM-observed or repository-fallback required.
 - Customer adopts the shared path for currently cached detail and email lookup families.
 - Hardcoded Customer detail/email TTLs are replaced by resolved policy objects.
 - Automatic CRUD invalidation and domain events enqueue refresh work after invalidation without blocking writes.
@@ -61,13 +64,15 @@ This creates three product risks:
 ## Key Requirements
 
 - Add shared cache-refresh DTOs with context, family, target identifiers, strategy, and event metadata.
+- Add a shared invalidation command/handler used by domain events, ODM events, and repository fallbacks.
 - Add shared invalidation DTOs/resolvers/collections for document-class, operation, and change-set driven tag resolution.
 - Add a shared Doctrine MongoDB ODM invalidation listener that invalidates after successful flush and can schedule `repository_refresh` work.
 - Add a generic `CacheRefreshCommand` and shared `CacheRefreshCommandHandler`.
 - Add abstract subscriber, factory, and context handler classes so bounded contexts only implement event mapping and warmup logic.
 - Add Customer policy collection/resolver/target resolver/handler adapters through existing directories.
 - Add Customer invalidation rule/tag adapters through existing Infrastructure collection/resolver directories.
-- Keep Customer cache invalidation subscribers narrow, using them only where domain-event scheduling is still needed beyond automatic CRUD invalidation.
+- Keep Customer cache invalidation subscribers as the automatic domain-event invalidation path, with idempotent overlap against ODM invalidation.
+- Review custom repositories and require fallback invalidation only for methods that bypass managed ODM document changes.
 - Use environment-overridable TTL/jitter parameters in Symfony service config.
 - Add shared typed metrics for refresh scheduled, success, failure, stale served, hit, and miss.
 - Keep cache, queue, and metric failures best effort.
@@ -84,6 +89,6 @@ This creates three product risks:
 
 ## Open Questions
 
-- Should Customer type/status create/update/delete operations publish domain events in a follow-up so reference-data refresh can be fully event-driven?
+- Should Customer type/status create/update/delete operations publish domain events in a follow-up for business semantics beyond cache invalidation?
 - Should collection endpoint caching be implemented through an API Platform provider decorator in a later issue?
-- Are there any production write paths that bypass ODM UnitOfWork change sets and need explicit repository-level invalidation fallback?
+- Are there any production write paths outside current repositories that bypass ODM UnitOfWork change sets and need explicit repository-level invalidation fallback?

--- a/specs/issue-176-async-cache-refresh/product-brief.md
+++ b/specs/issue-176-async-cache-refresh/product-brief.md
@@ -1,29 +1,35 @@
-# Product Brief: Async Endpoint Cache Refresh
+# Product Brief: Abstract Async Endpoint Cache Refresh
 
 ## Problem
 
 Customer reads are cached, but cache consistency is still request-path driven. Domain events invalidate cache tags, and the next user read may pay the cost to rebuild the affected cache entry. Cache policy is also spread across repository methods and Symfony cache pool defaults instead of being declared per endpoint/query family.
 
+Solving this only with Customer-specific commands and workers would create a second product risk: every future bounded context would need to copy the same refresh queue, worker, metrics, and failure behavior.
+
 This creates three product risks:
 
-- Write endpoints stay available, but related read endpoints can go cold after every write.
+- Related read endpoints can go cold after every write.
 - TTL choices are hardcoded and hard to justify or tune by data volatility.
-- Operators cannot see enough cache refresh lifecycle signals to tell whether async consistency is healthy.
+- Operators and developers cannot see enough reusable cache refresh lifecycle signals to tell whether async consistency is healthy across features.
 
 ## Stakeholders
 
-- API consumers who expect customer reads to become fresh shortly after writes.
-- Operators who need visibility into cache refresh scheduling, success, failure, and stale reads.
-- Developers who need a clear cache policy contract for every cached customer query family.
+- API consumers who expect reads to become fresh shortly after writes.
+- Operators who need visibility into refresh scheduling, success, failure, and stale reads.
+- Platform developers who need one reusable cache refresh pattern.
+- Future feature teams that need to adopt cache refresh without designing their own queue or worker.
+- Customer feature developers who need the first concrete adopter for detail and email lookup refresh.
 
 ## Goals
 
-- Declare cache policy centrally for every customer cached endpoint/query family.
-- Split customer cache behavior by family: detail, lookup, collection, and reference data.
-- Keep business writes fast by invalidating cache and scheduling refresh work asynchronously.
-- Route refresh work through Symfony Messenger using SQS in non-test environments and LocalStack for local/test parity.
-- Emit typed EMF metrics for cache refresh lifecycle and cache read behavior.
-- Add unit/integration/load evidence for invalidation, async refresh, TTL jitter, and post-write cache freshness.
+- Add one reusable cache refresh orchestration that can be adopted by any bounded context.
+- Keep the existing domain-event worker as the ingress for any domain event.
+- Add one generic refresh command payload, one shared `cache-refresh` queue, and one shared worker.
+- Keep context-specific mapping in bounded-context adapters.
+- Implement Customer detail and email lookup refresh as the first adoption.
+- Declare Customer collection and reference policies now, while keeping arbitrary proactive collection warmup out of scope until a deterministic query abstraction exists.
+- Emit shared typed EMF metrics for cache refresh lifecycle and cache read behavior where detectable.
+- Add unit, integration, and performance evidence for invalidation, async refresh, TTL jitter, and post-write cache freshness.
 
 ## Non-Goals
 
@@ -31,13 +37,16 @@ This creates three product risks:
 - Do not move Domain entities or repositories into framework-dependent code.
 - Do not implement arbitrary API Platform collection materialization beyond stable query shapes. A stable query shape has a deterministic key and parameter set, such as a customer list filtered by status; arbitrary materialization means warming ad-hoc API Platform filter combinations without a repository query contract. See [architecture.md](architecture.md) for the collection caching strategy.
 - Do not block writes on refresh success.
+- Do not create per-domain cache-refresh queues in the first implementation.
+- Do not introduce `ReadModel`, `Message`, `MessageHandler`, `Scheduler`, `Registry`, `Policy`, or context-level `Cache` directories.
 - Do not lower quality, coverage, mutation, architecture, or style thresholds.
 
 ## Success Metrics
 
-- All currently cached customer query families use declared policy objects instead of hardcoded TTL constants.
-- Domain events enqueue refresh work after invalidation.
-- Cache refresh command handler warms affected customer detail and email lookup entries without a user request.
+- One shared refresh command, queue, and worker path can refresh cache entries for any registered bounded-context adapter.
+- Customer adopts the shared path for currently cached detail and email lookup families.
+- Hardcoded Customer detail/email TTLs are replaced by resolved policy objects.
+- Domain events enqueue refresh work after invalidation without blocking writes.
 - Refresh failures are logged and measured but do not fail domain-event processing.
 - Local and CI Messenger routing works with in-memory test transport, SQS runtime transport, and LocalStack-backed local transport.
 - `make ci` passes.
@@ -45,22 +54,24 @@ This creates three product risks:
 
 ## Key Requirements
 
-- Add typed cache policy DTO/factory/collection/resolver classes with namespace, tags, soft TTL, hard TTL, jitter, consistency class, and refresh strategy.
+- Add shared cache-refresh DTOs with context, family, target identifiers, strategy, and event metadata.
+- Add a generic `RefreshCacheCommand` and shared `RefreshCacheCommandHandler`.
+- Add abstract subscriber, factory, and context handler classes so bounded contexts only implement event mapping and warmup logic.
+- Add Customer policy collection/resolver/target resolver/handler adapters through existing directories.
+- Update Customer cache invalidation subscribers to invalidate and schedule same-entity refresh workloads through the shared path.
 - Use environment-overridable TTL/jitter parameters in Symfony service config.
-- Add dedicated `RefreshCustomerCacheCommand` and command handler routed through Messenger.
-- Update customer cache invalidation subscribers to invalidate and schedule same-entity refresh workloads.
-- Add typed metrics for refresh scheduled, success, failure, stale served, hit, and miss.
-- Keep cache and metric failures best effort.
-- Update documentation for TTL defaults and operations.
+- Add shared typed metrics for refresh scheduled, success, failure, stale served, hit, and miss.
+- Keep cache, queue, and metric failures best effort.
+- Update documentation for shared orchestration, Customer first adoption, TTL defaults, and operations.
 
 ## Assumptions
 
-- First implementation focuses background refresh on currently cached customer detail and email lookup entries.
-- Same-entity refresh workloads mean refresh jobs for the specific cache keys affected by the domain event, such as customer detail by ID and lookup by email. They do not include arbitrary collection query refreshes.
+- First implementation focuses background refresh on currently cached Customer detail and email lookup entries.
+- Same-entity refresh workloads mean refresh jobs for the specific cache keys affected by the domain event, such as Customer detail by ID and lookup by email. They do not include arbitrary collection query refreshes.
 - Collection and reference-data policies are declared and tags are invalidated immediately. Async refresh for collections remains a follow-up unless a deterministic query-shape abstraction exists; until then, collection entries stay request-path cached after invalidation instead of being warmed proactively.
-- Integration tests can invoke the command handler directly for deterministic proof while unit tests cover Messenger routing and command dispatch.
+- Integration tests can invoke the shared worker and Customer handler directly for deterministic proof while unit tests cover Messenger routing and command dispatch.
 
 ## Open Questions
 
-- Should customer type/status create/update/delete operations publish domain events in a follow-up so reference-data refresh can be fully event-driven?
+- Should Customer type/status create/update/delete operations publish domain events in a follow-up so reference-data refresh can be fully event-driven?
 - Should collection endpoint caching be implemented through an API Platform provider decorator in a later issue?

--- a/specs/issue-176-async-cache-refresh/research.md
+++ b/specs/issue-176-async-cache-refresh/research.md
@@ -1,8 +1,8 @@
-# Research: Issue 176 Async Endpoint Cache Refresh
+# Research: Issue 176 Abstract Async Endpoint Cache Refresh
 
 ## Issue Scope
 
-GitHub issue #176 asks for endpoint-grade cache consistency for customer-facing cached query shapes. The requested outcome is not just invalidation: domain events must invalidate affected cache tags and enqueue dedicated cache refresh work that runs in Symfony Messenger workers backed by AWS SQS, while LocalStack remains the local transport.
+GitHub issue #176 asks for endpoint-grade cache consistency. The planned solution should create a reusable domain-event-driven cache refresh foundation, with Customer as the first adopter. The requested outcome is not just invalidation: domain events must invalidate affected cache tags and enqueue dedicated cache refresh work that runs in Symfony Messenger workers backed by AWS SQS, while LocalStack remains the local transport.
 
 ## Current State
 
@@ -64,14 +64,31 @@ Load and cache tests already exist:
 - Cache operations must be best effort and must not break business writes.
 - Event subscribers may live in Application and can depend on Infrastructure per the current deptrac rules.
 - Async cache refresh should reuse the repo's CQRS command directories: `Application/Command` and `Application/CommandHandler`.
-- Cache policy structure should reuse existing type directories such as `Application/DTO`, `Application/Factory`, `Infrastructure/Collection`, and `Infrastructure/Resolver`.
-- Do not introduce new Customer `Infrastructure/Cache`, `ReadModel`, `Policy`, `Registry`, `Scheduler`, `Message`, or `MessageHandler` directories for this feature unless the implementation first proves the current source tree and `deptrac.yaml` already support that directory type.
+- Shared metrics should reuse `Shared/Application/Observability/Metric`.
+- Cache policy structure should reuse existing type directories such as `DTO`, `Factory`, `Collection`, and `Resolver`.
+- Do not introduce new context `Infrastructure/Cache`, `ReadModel`, `Policy`, `Registry`, `Scheduler`, `Message`, or `MessageHandler` directories for this feature unless the implementation first proves the current source tree and `deptrac.yaml` already support that directory type.
 
 ## Implementation Surface
 
-Likely production code changes:
+### Shared Reusable Orchestration
 
-- Add endpoint cache policy DTO/factory/collection/resolver classes under the existing Customer Application and Infrastructure directories.
+Likely shared production code changes:
+
+- Add a generic `RefreshCacheCommand` under `Shared/Application/Command` with scalar context, family, target identifiers, strategy, and event metadata.
+- Add a generic `RefreshCacheCommandHandler` under `Shared/Application/CommandHandler` as the single Messenger worker entrypoint.
+- Add `AbstractCacheInvalidationSubscriber`, `AbstractCacheRefreshCommandFactory`, and `AbstractCacheRefreshCommandHandler` for reusable event-to-refresh orchestration and context handler behavior.
+- Add shared cache policy/target/result DTOs, resolver interfaces, handler resolver, handler collection, policy collection, and target resolver collection.
+- Add shared cache refresh lifecycle metrics under `Shared/Application/Observability/Metric`.
+- Add generic cache key helpers to `CacheKeyBuilder` if needed.
+- Add `cache-refresh` and `failed-cache-refresh` transports while keeping the existing `domain-events` transport unchanged.
+
+### Customer Adopter Changes
+
+Likely Customer production code changes:
+
+- Add Customer cache policy collection/resolver and refresh target resolver under existing Infrastructure directories.
+- Add `CustomerCacheRefreshCommandFactory` under `Application/Factory`.
+- Add `CustomerCacheRefreshCommandHandler` under `Application/CommandHandler` as a registered adapter for the shared worker.
 - Add customer endpoint cache policy configuration in `config/services.yaml` with environment-overridable TTLs and jitter.
 - Split cache pools in `config/packages/cache.yaml` and `config/packages/test/cache.yaml`, likely:
   - `cache.customer.detail`
@@ -79,23 +96,21 @@ Likely production code changes:
   - `cache.customer.collection`
   - `cache.customer.reference`
 - Update `CachedCustomerRepository` to use declared policies for customer detail and email lookup instead of method-local TTL constants.
-- Add `RefreshCustomerCacheCommand` and `RefreshCustomerCacheCommandHandler` routed through Messenger to SQS in non-test environments.
-- Add a command factory and target resolver that event subscribers use after invalidation.
-- Update create/update/delete invalidation subscribers to enqueue same-entity refresh workloads for affected families.
-- Add typed cache refresh lifecycle metrics for scheduled, succeeded, failed, stale served, and cache lookup hit/miss where feasible.
-- Update docs for cache policies, TTL defaults, LocalStack/SQS refresh routing, and operational metrics.
+- Update create/update/delete invalidation subscribers to invalidate and enqueue same-entity refresh workloads for affected families through the shared path.
+- Update docs for shared refresh orchestration, Customer policies, TTL defaults, LocalStack/SQS refresh routing, and operational metrics.
 
 Potential test changes:
 
-- Unit tests for cache policy construction, collection lookup, resolver behavior, TTL jitter bounds, and key/tag schema.
-- Unit tests for refresh command creation from create/update/delete subscribers.
-- Unit tests for refresh command handler success, missing entity/negative cache handling, and failure metric emission.
-- Integration tests that publish customer domain events and verify cache entries are repopulated by the refresh handler after invalidation.
+- Unit tests for shared command serialization, handler delegation, handler failure isolation, subscriber/factory behavior, policy construction, resolver behavior, TTL jitter bounds, and metric dimensions.
+- Unit tests for Customer refresh command creation from create/update/delete subscribers.
+- Unit tests for Customer refresh handler success, missing entity/negative cache handling, and failure metric emission.
+- Integration tests that publish Customer domain events and verify cache entries are repopulated by the shared worker plus Customer handler after invalidation.
 - Existing cache performance tests should continue to pass.
 - Existing K6 cache performance smoke scenario can be used as load evidence.
 
 ## Key Risks
 
+- A generic shared design may still carry Customer-only payload assumptions. The payload must use feature-neutral fields and leave Customer-specific mapping in the Customer adapter.
 - API Platform collection caching is not currently repository-level, so adding full collection refresh for arbitrary filters may exceed a safe first implementation. Forward-safe policy classes can declare collection policies while the first worker refreshes known detail/email workloads and invalidates collection tags.
 - Customer type/status operations do not publish domain events today, so reference-data cache refresh should either be limited to declared policy plus current invalidation behavior or be split into a follow-up if events are missing.
 - Symfony cache `get()` does not expose simple hit/miss hooks; hit/miss metrics may require a wrapper service or conservative instrumentation around callback execution.
@@ -104,10 +119,10 @@ Potential test changes:
 
 ## Planning Assumptions
 
-- The first PR should implement cache policy DTO/factory/collection/resolver classes, split pools, and async refresh for the currently cached customer detail and email lookup families.
+- The first implementation should deliver the shared refresh foundation plus Customer adoption for currently cached detail and email lookup families.
 - Customer collection and customer reference-data policies should be declared and documented, with collection tags still invalidated. Full arbitrary collection materialization can remain policy-ready unless the codebase exposes a stable cacheable query abstraction during implementation.
 - Cache refresh failures should be logged and measured but must not rethrow into business writes or domain event processing.
-- Tests should prefer direct handler invocation for deterministic refresh verification, while Messenger routing config proves SQS/local transport wiring.
+- Tests should prefer direct worker and handler invocation for deterministic refresh verification, while Messenger routing config proves SQS/local transport wiring.
 
 ## Commands Run During Research
 

--- a/specs/issue-176-async-cache-refresh/research.md
+++ b/specs/issue-176-async-cache-refresh/research.md
@@ -18,7 +18,7 @@ The current cache model is still method-local and partly hardcoded:
 
 - Customer detail TTL is hardcoded at 600 seconds in `CachedCustomerRepository::loadCustomerFromDb()`.
 - Customer email lookup TTL is hardcoded at 300 seconds in `CachedCustomerRepository::loadCustomerByEmail()`.
-- Policy comments live near methods instead of a first-class endpoint/query policy registry.
+- Policy comments live near methods instead of first-class endpoint/query policy classes.
 - `buildCustomerCollectionKey()` exists, but collection endpoint caching is not implemented in the repository decorator.
 - Customer status/type reference endpoints are not cached in dedicated repository decorators.
 
@@ -63,13 +63,15 @@ Load and cache tests already exist:
 - Use `TagAwareCacheInterface` for tagged cache operations.
 - Cache operations must be best effort and must not break business writes.
 - Event subscribers may live in Application and can depend on Infrastructure per the current deptrac rules.
-- Dedicated Messenger messages and handlers should live in Application `Message` / `MessageHandler` or Infrastructure bus paths that match existing deptrac collectors.
+- Async cache refresh should reuse the repo's CQRS command directories: `Application/Command` and `Application/CommandHandler`.
+- Cache policy structure should reuse existing type directories such as `Application/DTO`, `Application/Factory`, `Infrastructure/Collection`, and `Infrastructure/Resolver`.
+- Do not introduce new Customer `Infrastructure/Cache`, `ReadModel`, `Policy`, `Registry`, `Scheduler`, `Message`, or `MessageHandler` directories for this feature unless the implementation first proves the current source tree and `deptrac.yaml` already support that directory type.
 
 ## Implementation Surface
 
 Likely production code changes:
 
-- Add endpoint cache policy value objects/registry under `src/Core/Customer/Application` or `src/Shared/Application`.
+- Add endpoint cache policy DTO/factory/collection/resolver classes under the existing Customer Application and Infrastructure directories.
 - Add customer endpoint cache policy configuration in `config/services.yaml` with environment-overridable TTLs and jitter.
 - Split cache pools in `config/packages/cache.yaml` and `config/packages/test/cache.yaml`, likely:
   - `cache.customer.detail`
@@ -77,24 +79,24 @@ Likely production code changes:
   - `cache.customer.collection`
   - `cache.customer.reference`
 - Update `CachedCustomerRepository` to use declared policies for customer detail and email lookup instead of method-local TTL constants.
-- Add a dedicated cache refresh message and handler routed through Messenger to SQS in non-test environments.
-- Add a refresh dispatcher/scheduler that event subscribers call after invalidation.
+- Add `RefreshCustomerCacheCommand` and `RefreshCustomerCacheCommandHandler` routed through Messenger to SQS in non-test environments.
+- Add a command factory and target resolver that event subscribers use after invalidation.
 - Update create/update/delete invalidation subscribers to enqueue same-entity refresh workloads for affected families.
 - Add typed cache refresh lifecycle metrics for scheduled, succeeded, failed, stale served, and cache lookup hit/miss where feasible.
 - Update docs for cache policies, TTL defaults, LocalStack/SQS refresh routing, and operational metrics.
 
 Potential test changes:
 
-- Unit tests for cache policy registry lookup, TTL jitter bounds, and key/tag schema.
-- Unit tests for refresh scheduling from create/update/delete subscribers.
-- Unit tests for refresh handler success, missing entity/negative cache handling, and failure metric emission.
+- Unit tests for cache policy construction, collection lookup, resolver behavior, TTL jitter bounds, and key/tag schema.
+- Unit tests for refresh command creation from create/update/delete subscribers.
+- Unit tests for refresh command handler success, missing entity/negative cache handling, and failure metric emission.
 - Integration tests that publish customer domain events and verify cache entries are repopulated by the refresh handler after invalidation.
 - Existing cache performance tests should continue to pass.
 - Existing K6 cache performance smoke scenario can be used as load evidence.
 
 ## Key Risks
 
-- API Platform collection caching is not currently repository-level, so adding full collection refresh for arbitrary filters may exceed a safe first implementation. A forward-safe policy registry can declare collection policies while the first worker refreshes known detail/email workloads and invalidates collection tags.
+- API Platform collection caching is not currently repository-level, so adding full collection refresh for arbitrary filters may exceed a safe first implementation. Forward-safe policy classes can declare collection policies while the first worker refreshes known detail/email workloads and invalidates collection tags.
 - Customer type/status operations do not publish domain events today, so reference-data cache refresh should either be limited to declared policy plus current invalidation behavior or be split into a follow-up if events are missing.
 - Symfony cache `get()` does not expose simple hit/miss hooks; hit/miss metrics may require a wrapper service or conservative instrumentation around callback execution.
 - Messenger routing must keep the current domain event queue working and add a separate cache refresh route without breaking LocalStack.
@@ -102,7 +104,7 @@ Potential test changes:
 
 ## Planning Assumptions
 
-- The first PR should implement the cache policy registry, split pools, and async refresh for the currently cached customer detail and email lookup families.
+- The first PR should implement cache policy DTO/factory/collection/resolver classes, split pools, and async refresh for the currently cached customer detail and email lookup families.
 - Customer collection and customer reference-data policies should be declared and documented, with collection tags still invalidated. Full arbitrary collection materialization can remain policy-ready unless the codebase exposes a stable cacheable query abstraction during implementation.
 - Cache refresh failures should be logged and measured but must not rethrow into business writes or domain event processing.
 - Tests should prefer direct handler invocation for deterministic refresh verification, while Messenger routing config proves SQS/local transport wiring.

--- a/specs/issue-176-async-cache-refresh/research.md
+++ b/specs/issue-176-async-cache-refresh/research.md
@@ -74,8 +74,8 @@ Load and cache tests already exist:
 
 Likely shared production code changes:
 
-- Add a generic `RefreshCacheCommand` under `Shared/Application/Command` with scalar context, family, target identifiers, strategy, and event metadata.
-- Add a generic `RefreshCacheCommandHandler` under `Shared/Application/CommandHandler` as the single Messenger worker entrypoint.
+- Add a generic `CacheRefreshCommand` under `Shared/Application/Command` with scalar context, family, target identifiers, strategy, and event metadata.
+- Add a generic `CacheRefreshCommandHandler` under `Shared/Application/CommandHandler` as the single Messenger worker entrypoint.
 - Add `AbstractCacheInvalidationSubscriber`, `AbstractCacheRefreshCommandFactory`, and `AbstractCacheRefreshCommandHandler` for reusable event-to-refresh orchestration and context handler behavior.
 - Add shared cache policy/target/result DTOs, resolver interfaces, handler resolver, handler collection, policy collection, and target resolver collection.
 - Add shared cache refresh lifecycle metrics under `Shared/Application/Observability/Metric`.

--- a/specs/issue-176-async-cache-refresh/research.md
+++ b/specs/issue-176-async-cache-refresh/research.md
@@ -2,7 +2,7 @@
 
 ## Issue Scope
 
-GitHub issue #176 asks for endpoint-grade cache consistency. The planned solution should create a reusable domain-event-driven cache refresh foundation, with Customer as the first adopter. The requested outcome is not just invalidation: domain events must invalidate affected cache tags and enqueue dedicated cache refresh work that runs in Symfony Messenger workers backed by AWS SQS, while LocalStack remains the local transport.
+GitHub issue #176 asks for endpoint-grade cache consistency. The planned solution should create reusable automatic CRUD invalidation plus an async cache refresh foundation, with Customer as the first adopter. The requested outcome is not just invalidation: writes and domain events must invalidate affected cache tags and enqueue dedicated cache refresh work that runs in Symfony Messenger workers backed by AWS SQS, while LocalStack remains the local transport.
 
 ## Current State
 
@@ -38,6 +38,18 @@ Customer cache invalidation currently happens in domain event subscribers:
 
 Those subscribers only invalidate tags. They do not enqueue dedicated refresh work or warm cache entries in background workers.
 
+The current Customer events are sufficient for invalidation but not sufficient for event-only refresh:
+
+- `CustomerCreatedEvent` carries customer ID and email.
+- `CustomerUpdatedEvent` carries customer ID, current email, and previous email.
+- `CustomerDeletedEvent` carries customer ID and email.
+- `CachedCustomerRepository` caches full `Customer` objects for `find()` and `findByEmail()`.
+- A cacheable Customer object includes fields beyond event identifiers, such as initials, phone, lead source, type, status, confirmation state, ULID, and timestamps.
+
+Therefore the first implementation should refresh from persisted state through a context adapter. Event-snapshot refresh can be added later only if events carry complete, versioned, serialization-stable payloads and stale-overwrite guards.
+
+Repository writes generally flow through `BaseRepository::save()` and `BaseRepository::delete()`, but some infrastructure repositories also define custom delete methods that call `DocumentManager` directly. A generic Doctrine MongoDB ODM listener can inspect scheduled insertions, updates, deletions, and change sets at flush time, then invalidate tags after a successful flush. This is a better shared invalidation point than adding one cache repository per entity or adding cache invalidation methods to Domain repository interfaces.
+
 Observability already uses typed EMF business metrics:
 
 - Application metric classes extend `BusinessMetric`.
@@ -66,6 +78,8 @@ Load and cache tests already exist:
 - Async cache refresh should reuse the repo's CQRS command directories: `Application/Command` and `Application/CommandHandler`.
 - Shared metrics should reuse `Shared/Application/Observability/Metric`.
 - Cache policy structure should reuse existing type directories such as `DTO`, `Factory`, `Collection`, and `Resolver`.
+- Automatic CRUD invalidation should live in `Shared/Infrastructure/EventListener` and use existing `Collection` and `Resolver` directory types for mapping.
+- Domain repository interfaces should remain cache-free. Invalidation rules belong to infrastructure/application adapters.
 - Do not introduce new context `Infrastructure/Cache`, `ReadModel`, `Policy`, `Registry`, `Scheduler`, `Message`, or `MessageHandler` directories for this feature unless the implementation first proves the current source tree and `deptrac.yaml` already support that directory type.
 
 ## Implementation Surface
@@ -79,6 +93,8 @@ Likely shared production code changes:
 - Add `AbstractCacheInvalidationSubscriber`, `AbstractCacheRefreshCommandFactory`, and `AbstractCacheRefreshCommandHandler` for reusable event-to-refresh orchestration and context handler behavior.
 - Add shared cache policy/target/result DTOs, resolver interfaces, handler resolver, handler collection, policy collection, and target resolver collection.
 - Add shared cache refresh lifecycle metrics under `Shared/Application/Observability/Metric`.
+- Add `CacheInvalidationDoctrineEventListener` under `Shared/Infrastructure/EventListener` to collect ODM change-set driven invalidation and scheduling work.
+- Add shared invalidation rule collection and tag resolver classes under existing Shared Infrastructure `Collection` and `Resolver` directories.
 - Add generic cache key helpers to `CacheKeyBuilder` if needed.
 - Add `cache-refresh` and `failed-cache-refresh` transports while keeping the existing `domain-events` transport unchanged.
 
@@ -87,6 +103,7 @@ Likely shared production code changes:
 Likely Customer production code changes:
 
 - Add Customer cache policy collection/resolver and refresh target resolver under existing Infrastructure directories.
+- Add Customer cache invalidation rule collection/resolver under existing Infrastructure directories.
 - Add `CustomerCacheRefreshCommandFactory` under `Application/Factory`.
 - Add `CustomerCacheRefreshCommandHandler` under `Application/CommandHandler` as a registered adapter for the shared worker.
 - Add customer endpoint cache policy configuration in `config/services.yaml` with environment-overridable TTLs and jitter.
@@ -96,21 +113,26 @@ Likely Customer production code changes:
   - `cache.customer.collection`
   - `cache.customer.reference`
 - Update `CachedCustomerRepository` to use declared policies for customer detail and email lookup instead of method-local TTL constants.
-- Update create/update/delete invalidation subscribers to invalidate and enqueue same-entity refresh workloads for affected families through the shared path.
+- Update create/update/delete invalidation so normal ODM writes are covered by the shared listener; keep Customer event subscribers only for domain-event scheduling responsibilities that are not already covered by CRUD invalidation.
 - Update docs for shared refresh orchestration, Customer policies, TTL defaults, LocalStack/SQS refresh routing, and operational metrics.
 
 Potential test changes:
 
 - Unit tests for shared command serialization, handler delegation, handler failure isolation, subscriber/factory behavior, policy construction, resolver behavior, TTL jitter bounds, and metric dimensions.
+- Unit tests for ODM listener insert/update/delete handling, old/new tag resolution, post-flush invalidation, and best-effort failure behavior.
 - Unit tests for Customer refresh command creation from create/update/delete subscribers.
+- Unit tests for Customer invalidation rules and automatic old/new email tag resolution.
 - Unit tests for Customer refresh handler success, missing entity/negative cache handling, and failure metric emission.
-- Integration tests that publish Customer domain events and verify cache entries are repopulated by the shared worker plus Customer handler after invalidation.
+- Integration tests that perform Customer create/update/delete writes and verify cache entries are invalidated and repopulated by the shared worker plus Customer handler after invalidation.
 - Existing cache performance tests should continue to pass.
 - Existing K6 cache performance smoke scenario can be used as load evidence.
 
 ## Key Risks
 
 - A generic shared design may still carry Customer-only payload assumptions. The payload must use feature-neutral fields and leave Customer-specific mapping in the Customer adapter.
+- A generic ODM listener can become too implicit if rules are not explicit. Keep document-class, operation, and field mappings in typed collection/resolver classes with focused tests.
+- Bulk writes or direct database operations that bypass ODM UnitOfWork change sets may bypass automatic invalidation. The first implementation should document this limitation and only add repository fallbacks when tests prove a real bypass.
+- Event-snapshot refresh can overwrite good cache with incomplete or stale data if events are not complete and versioned. Current Customer events should use invalidation plus `repository_refresh`, not `event_snapshot`.
 - API Platform collection caching is not currently repository-level, so adding full collection refresh for arbitrary filters may exceed a safe first implementation. Forward-safe policy classes can declare collection policies while the first worker refreshes known detail/email workloads and invalidates collection tags.
 - Customer type/status operations do not publish domain events today, so reference-data cache refresh should either be limited to declared policy plus current invalidation behavior or be split into a follow-up if events are missing.
 - Symfony cache `get()` does not expose simple hit/miss hooks; hit/miss metrics may require a wrapper service or conservative instrumentation around callback execution.
@@ -120,6 +142,8 @@ Potential test changes:
 ## Planning Assumptions
 
 - The first implementation should deliver the shared refresh foundation plus Customer adoption for currently cached detail and email lookup families.
+- Automatic CRUD invalidation should be implemented through a shared ODM listener and Customer mapping adapters, not through per-entity cache repositories.
+- The default refresh source should be `repository_refresh`; `event_snapshot` is future-only unless events contain complete, versioned cache snapshots.
 - Customer collection and customer reference-data policies should be declared and documented, with collection tags still invalidated. Full arbitrary collection materialization can remain policy-ready unless the codebase exposes a stable cacheable query abstraction during implementation.
 - Cache refresh failures should be logged and measured but must not rethrow into business writes or domain event processing.
 - Tests should prefer direct worker and handler invocation for deterministic refresh verification, while Messenger routing config proves SQS/local transport wiring.

--- a/specs/issue-176-async-cache-refresh/research.md
+++ b/specs/issue-176-async-cache-refresh/research.md
@@ -2,7 +2,7 @@
 
 ## Issue Scope
 
-GitHub issue #176 asks for endpoint-grade cache consistency. The planned solution should create reusable automatic CRUD invalidation plus an async cache refresh foundation, with Customer as the first adopter. The requested outcome is not just invalidation: writes and domain events must invalidate affected cache tags and enqueue dedicated cache refresh work that runs in Symfony Messenger workers backed by AWS SQS, while LocalStack remains the local transport.
+GitHub issue #176 asks for endpoint-grade cache consistency. The planned solution should create reusable layered invalidation plus an async cache refresh foundation, with Customer as the first adopter. The requested outcome is not just invalidation: writes, exposed domain events, and custom repository paths must invalidate affected cache tags and enqueue dedicated cache refresh work that runs in Symfony Messenger workers backed by AWS SQS, while LocalStack remains the local transport.
 
 ## Current State
 
@@ -48,7 +48,13 @@ The current Customer events are sufficient for invalidation but not sufficient f
 
 Therefore the first implementation should refresh from persisted state through a context adapter. Event-snapshot refresh can be added later only if events carry complete, versioned, serialization-stable payloads and stale-overwrite guards.
 
-Repository writes generally flow through `BaseRepository::save()` and `BaseRepository::delete()`, but some infrastructure repositories also define custom delete methods that call `DocumentManager` directly. A generic Doctrine MongoDB ODM listener can inspect scheduled insertions, updates, deletions, and change sets at flush time, then invalidate tags after a successful flush. This is a better shared invalidation point than adding one cache repository per entity or adding cache invalidation methods to Domain repository interfaces.
+Repository writes generally flow through `BaseRepository::save()` and `BaseRepository::delete()`, but some infrastructure repositories also define custom delete methods. `MongoCustomerRepository::deleteByEmail()` and `deleteById()` load managed Customer documents and delegate deletion. `MongoTypeRepository::deleteByValue()` and `MongoStatusRepository::deleteByValue()` remove managed documents and flush. A generic Doctrine MongoDB ODM listener can inspect scheduled insertions, updates, deletions, and change sets at flush time, then invalidate tags after a successful flush. This is a better shared invalidation point than adding one cache repository per entity or adding cache invalidation methods to Domain repository interfaces.
+
+The design still needs a repository fallback for custom methods that do not produce ODM UnitOfWork change sets, such as future bulk update/delete query builder operations or external database writes. Those methods should call the shared invalidation command after successful write completion. This keeps all invalidation sources on the same rule/tag resolver surface:
+
+- domain events
+- ODM document change sets
+- repository fallback calls for unobservable custom writes
 
 Observability already uses typed EMF business metrics:
 
@@ -93,6 +99,7 @@ Likely shared production code changes:
 - Add `AbstractCacheInvalidationSubscriber`, `AbstractCacheRefreshCommandFactory`, and `AbstractCacheRefreshCommandHandler` for reusable event-to-refresh orchestration and context handler behavior.
 - Add shared cache policy/target/result DTOs, resolver interfaces, handler resolver, handler collection, policy collection, and target resolver collection.
 - Add shared cache refresh lifecycle metrics under `Shared/Application/Observability/Metric`.
+- Add a generic `CacheInvalidationCommand` and handler used by domain event subscribers, the ODM listener, and repository fallbacks.
 - Add `CacheInvalidationDoctrineEventListener` under `Shared/Infrastructure/EventListener` to collect ODM change-set driven invalidation and scheduling work.
 - Add shared invalidation rule collection and tag resolver classes under existing Shared Infrastructure `Collection` and `Resolver` directories.
 - Add generic cache key helpers to `CacheKeyBuilder` if needed.
@@ -113,13 +120,15 @@ Likely Customer production code changes:
   - `cache.customer.collection`
   - `cache.customer.reference`
 - Update `CachedCustomerRepository` to use declared policies for customer detail and email lookup instead of method-local TTL constants.
-- Update create/update/delete invalidation so normal ODM writes are covered by the shared listener; keep Customer event subscribers only for domain-event scheduling responsibilities that are not already covered by CRUD invalidation.
+- Update create/update/delete invalidation so normal ODM writes are covered by the shared listener, exposed Customer domain events are covered by subscribers, and any custom repository method that bypasses ODM observation calls the shared invalidation command as a fallback.
 - Update docs for shared refresh orchestration, Customer policies, TTL defaults, LocalStack/SQS refresh routing, and operational metrics.
 
 Potential test changes:
 
 - Unit tests for shared command serialization, handler delegation, handler failure isolation, subscriber/factory behavior, policy construction, resolver behavior, TTL jitter bounds, and metric dimensions.
 - Unit tests for ODM listener insert/update/delete handling, old/new tag resolution, post-flush invalidation, and best-effort failure behavior.
+- Unit tests for domain-event subscriber invalidation through the shared invalidation command.
+- Unit tests for repository fallback invalidation for any custom write method that bypasses ODM observation.
 - Unit tests for Customer refresh command creation from create/update/delete subscribers.
 - Unit tests for Customer invalidation rules and automatic old/new email tag resolution.
 - Unit tests for Customer refresh handler success, missing entity/negative cache handling, and failure metric emission.
@@ -131,10 +140,11 @@ Potential test changes:
 
 - A generic shared design may still carry Customer-only payload assumptions. The payload must use feature-neutral fields and leave Customer-specific mapping in the Customer adapter.
 - A generic ODM listener can become too implicit if rules are not explicit. Keep document-class, operation, and field mappings in typed collection/resolver classes with focused tests.
-- Bulk writes or direct database operations that bypass ODM UnitOfWork change sets may bypass automatic invalidation. The first implementation should document this limitation and only add repository fallbacks when tests prove a real bypass.
+- Bulk writes or direct database operations that bypass ODM UnitOfWork change sets may bypass automatic invalidation. The first implementation should classify custom repository methods and require repository fallback calls for any path that cannot be observed by ODM.
+- Domain-event invalidation and ODM invalidation may duplicate each other. This should be safe because tag invalidation is idempotent; refresh scheduling needs deterministic dedupe keys.
 - Event-snapshot refresh can overwrite good cache with incomplete or stale data if events are not complete and versioned. Current Customer events should use invalidation plus `repository_refresh`, not `event_snapshot`.
 - API Platform collection caching is not currently repository-level, so adding full collection refresh for arbitrary filters may exceed a safe first implementation. Forward-safe policy classes can declare collection policies while the first worker refreshes known detail/email workloads and invalidates collection tags.
-- Customer type/status operations do not publish domain events today, so reference-data cache refresh should either be limited to declared policy plus current invalidation behavior or be split into a follow-up if events are missing.
+- Customer type/status operations do not publish domain events today. Cache invalidation can still be covered through ODM listener rules for managed document changes; domain events are a follow-up only if business semantics or cross-context reactions require them.
 - Symfony cache `get()` does not expose simple hit/miss hooks; hit/miss metrics may require a wrapper service or conservative instrumentation around callback execution.
 - Messenger routing must keep the current domain event queue working and add a separate cache refresh route without breaking LocalStack.
 - The repo requires `make ci`; that includes mutation testing and can be slow.
@@ -142,7 +152,8 @@ Potential test changes:
 ## Planning Assumptions
 
 - The first implementation should deliver the shared refresh foundation plus Customer adoption for currently cached detail and email lookup families.
-- Automatic CRUD invalidation should be implemented through a shared ODM listener and Customer mapping adapters, not through per-entity cache repositories.
+- Automatic invalidation should be layered through domain-event subscribers, a shared ODM listener, and repository fallback calls for custom writes that bypass ODM observation.
+- Normal and custom repository methods that persist/remove managed documents and flush should rely on ODM listener coverage rather than per-entity cache repositories.
 - The default refresh source should be `repository_refresh`; `event_snapshot` is future-only unless events contain complete, versioned cache snapshots.
 - Customer collection and customer reference-data policies should be declared and documented, with collection tags still invalidated. Full arbitrary collection materialization can remain policy-ready unless the codebase exposes a stable cacheable query abstraction during implementation.
 - Cache refresh failures should be logged and measured but must not rethrow into business writes or domain event processing.

--- a/specs/issue-176-async-cache-refresh/research.md
+++ b/specs/issue-176-async-cache-refresh/research.md
@@ -1,0 +1,118 @@
+# Research: Issue 176 Async Endpoint Cache Refresh
+
+## Issue Scope
+
+GitHub issue #176 asks for endpoint-grade cache consistency for customer-facing cached query shapes. The requested outcome is not just invalidation: domain events must invalidate affected cache tags and enqueue dedicated cache refresh work that runs in Symfony Messenger workers backed by AWS SQS, while LocalStack remains the local transport.
+
+## Current State
+
+The service already has a Redis-backed tag-aware customer cache:
+
+- `config/packages/cache.yaml` defines `cache.customer` with Redis, default lifetime `600`, and tags enabled.
+- `config/packages/test/cache.yaml` mirrors `cache.customer` with an array adapter and tags enabled.
+- `src/Core/Customer/Infrastructure/Repository/CachedCustomerRepository.php` decorates `MongoCustomerRepository` and caches `find()` and `findByEmail()`.
+- `src/Shared/Infrastructure/Cache/CacheKeyBuilder.php` centralizes customer ID, email, and collection cache key construction.
+- `src/Core/Customer/Infrastructure/Collection/CustomerCacheTagCollection.php` and `src/Core/Customer/Infrastructure/Resolver/CustomerCacheTagResolver.php` centralize deletion tag resolution.
+
+The current cache model is still method-local and partly hardcoded:
+
+- Customer detail TTL is hardcoded at 600 seconds in `CachedCustomerRepository::loadCustomerFromDb()`.
+- Customer email lookup TTL is hardcoded at 300 seconds in `CachedCustomerRepository::loadCustomerByEmail()`.
+- Policy comments live near methods instead of a first-class endpoint/query policy registry.
+- `buildCustomerCollectionKey()` exists, but collection endpoint caching is not implemented in the repository decorator.
+- Customer status/type reference endpoints are not cached in dedicated repository decorators.
+
+The service already has async domain event delivery:
+
+- `config/packages/messenger.yaml` routes `DomainEventEnvelope` to the `domain-events` transport and failed envelopes to `failed-domain-events`.
+- `.env` configures SQS DSNs against LocalStack on port `4566`.
+- `src/Shared/Infrastructure/Bus/Event/Async/ResilientAsyncEventDispatcher.php` dispatches events through Messenger and isolates SQS dispatch failures from write requests.
+- `src/Shared/Infrastructure/Bus/Event/Async/DomainEventMessageHandler.php` invokes tagged domain event subscribers in workers, logs subscriber failures, emits metrics, and continues.
+- `config/services_test.yaml` swaps the event bus back to synchronous in-memory processing for integration tests.
+
+Customer cache invalidation currently happens in domain event subscribers:
+
+- `CustomerCreatedCacheInvalidationSubscriber` invalidates customer ID, customer email, and collection tags.
+- `CustomerUpdatedCacheInvalidationSubscriber` invalidates customer ID, current email, previous email when changed, and collection tags.
+- `CustomerDeletedCacheInvalidationSubscriber` invalidates customer ID, email, and collection tags.
+
+Those subscribers only invalidate tags. They do not enqueue dedicated refresh work or warm cache entries in background workers.
+
+Observability already uses typed EMF business metrics:
+
+- Application metric classes extend `BusinessMetric`.
+- Factories create metrics instead of hardcoding arrays.
+- `BusinessMetricsEmitterInterface` emits typed metrics.
+- Existing async failure metrics include `SqsDispatchFailureMetric` and `EventSubscriberFailureMetric`.
+- Tests use `BusinessMetricsEmitterSpy`.
+
+Load and cache tests already exist:
+
+- `make cache-performance-tests` runs `tests/Integration/Customer/Infrastructure/Repository/CachePerformanceTest.php`.
+- `make cache-performance-load-tests` runs the K6 `rest-api/cachePerformance` smoke scenario.
+- `tests/Load/scripts/rest-api/cachePerformance.js` warms customer reads and reports heuristic cache hit indicators.
+- Existing integration tests cover cache population, invalidation, SWR-style cache population, and delete cleanup.
+
+## Architecture Constraints
+
+- Follow the repository skills: cache-management, implementing-ddd-architecture, observability-instrumentation, load-testing, documentation-sync, testing-workflow, and ci-workflow.
+- Use Makefile targets or Docker container access only for PHP checks; do not run PHP directly on the host.
+- Keep Domain free of Symfony, Doctrine, API Platform, cache, Messenger, and logging dependencies.
+- Use typed classes and collections instead of array-shaped policies or metric payloads.
+- Use factories for complex object construction where needed.
+- Use `TagAwareCacheInterface` for tagged cache operations.
+- Cache operations must be best effort and must not break business writes.
+- Event subscribers may live in Application and can depend on Infrastructure per the current deptrac rules.
+- Dedicated Messenger messages and handlers should live in Application `Message` / `MessageHandler` or Infrastructure bus paths that match existing deptrac collectors.
+
+## Implementation Surface
+
+Likely production code changes:
+
+- Add endpoint cache policy value objects/registry under `src/Core/Customer/Application` or `src/Shared/Application`.
+- Add customer endpoint cache policy configuration in `config/services.yaml` with environment-overridable TTLs and jitter.
+- Split cache pools in `config/packages/cache.yaml` and `config/packages/test/cache.yaml`, likely:
+  - `cache.customer.detail`
+  - `cache.customer.lookup`
+  - `cache.customer.collection`
+  - `cache.customer.reference`
+- Update `CachedCustomerRepository` to use declared policies for customer detail and email lookup instead of method-local TTL constants.
+- Add a dedicated cache refresh message and handler routed through Messenger to SQS in non-test environments.
+- Add a refresh dispatcher/scheduler that event subscribers call after invalidation.
+- Update create/update/delete invalidation subscribers to enqueue same-entity refresh workloads for affected families.
+- Add typed cache refresh lifecycle metrics for scheduled, succeeded, failed, stale served, and cache lookup hit/miss where feasible.
+- Update docs for cache policies, TTL defaults, LocalStack/SQS refresh routing, and operational metrics.
+
+Potential test changes:
+
+- Unit tests for cache policy registry lookup, TTL jitter bounds, and key/tag schema.
+- Unit tests for refresh scheduling from create/update/delete subscribers.
+- Unit tests for refresh handler success, missing entity/negative cache handling, and failure metric emission.
+- Integration tests that publish customer domain events and verify cache entries are repopulated by the refresh handler after invalidation.
+- Existing cache performance tests should continue to pass.
+- Existing K6 cache performance smoke scenario can be used as load evidence.
+
+## Key Risks
+
+- API Platform collection caching is not currently repository-level, so adding full collection refresh for arbitrary filters may exceed a safe first implementation. A forward-safe policy registry can declare collection policies while the first worker refreshes known detail/email workloads and invalidates collection tags.
+- Customer type/status operations do not publish domain events today, so reference-data cache refresh should either be limited to declared policy plus current invalidation behavior or be split into a follow-up if events are missing.
+- Symfony cache `get()` does not expose simple hit/miss hooks; hit/miss metrics may require a wrapper service or conservative instrumentation around callback execution.
+- Messenger routing must keep the current domain event queue working and add a separate cache refresh route without breaking LocalStack.
+- The repo requires `make ci`; that includes mutation testing and can be slow.
+
+## Planning Assumptions
+
+- The first PR should implement the cache policy registry, split pools, and async refresh for the currently cached customer detail and email lookup families.
+- Customer collection and customer reference-data policies should be declared and documented, with collection tags still invalidated. Full arbitrary collection materialization can remain policy-ready unless the codebase exposes a stable cacheable query abstraction during implementation.
+- Cache refresh failures should be logged and measured but must not rethrow into business writes or domain event processing.
+- Tests should prefer direct handler invocation for deterministic refresh verification, while Messenger routing config proves SQS/local transport wiring.
+
+## Commands Run During Research
+
+- `bmalph -C ${REPO_ROOT} doctor --json`
+- `bmalph -C ${REPO_ROOT} status --json`
+- `gh issue view 176 --repo VilnaCRM-Org/core-service --comments --json ...`
+- `rg -n "Cache|Refresh|BusinessMetric|Messenger|SQS|TagAware|cache" src config tests docs tests/Load`
+- `find src/Core/Customer -maxdepth 4 -type f`
+- `find src/Shared -maxdepth 5 -type f`
+- `sed -n ...` on the cache, messenger, observability, test, and documentation files listed above.

--- a/specs/issue-176-async-cache-refresh/run-summary.md
+++ b/specs/issue-176-async-cache-refresh/run-summary.md
@@ -4,42 +4,42 @@ Bundle source: `_bmad-output/planning-artifacts/autonomous/<issue-176-artifact-b
 
 Tracked spec directory: `specs/issue-176-async-cache-refresh`
 
-Task: Plan GitHub issue #176, "Implement endpoint cache invalidation with async background refresh via SQS workers".
+Task: Plan GitHub issue #176, "Implement endpoint cache invalidation with async background refresh via SQS workers", as a shared reusable refresh foundation with Customer as the first adopter.
 
 Scope guard: This PR is planning-only and does not implement production code.
 
 ## Subagent Execution Log
 
-| Phase                    | BMALPH command             | Artifact                      | Status                                          |
-| ------------------------ | -------------------------- | ----------------------------- | ----------------------------------------------- |
-| Research                 | `analyst`                  | `research.md`                 | Complete, local recovery after subagent timeout |
-| Product brief            | `create-brief`             | `product-brief.md`            | Complete, local recovery after subagent timeout |
-| PRD                      | `create-prd`               | `prd.md`                      | Complete, local synthesis                       |
-| Architecture             | `create-architecture`      | `architecture.md`             | Complete, local synthesis                       |
-| Epics and stories        | `create-epics-stories`     | `epics.md`                    | Complete, local synthesis                       |
-| Implementation readiness | `implementation-readiness` | `implementation-readiness.md` | Complete, local synthesis                       |
+| Phase                    | BMALPH command             | Artifact                      | Status                                              |
+| ------------------------ | -------------------------- | ----------------------------- | --------------------------------------------------- |
+| Research                 | `analyst`                  | `research.md`                 | Complete, local recovery after subagent timeout     |
+| Product brief            | `create-brief`             | `product-brief.md`            | Complete, local recovery after subagent timeout     |
+| PRD                      | `create-prd`               | `prd.md`                      | Complete, local synthesis                           |
+| Architecture             | `create-architecture`      | `architecture.md`             | Complete, local synthesis and BMAD reviewer rewrite |
+| Epics and stories        | `create-epics-stories`     | `epics.md`                    | Complete, local synthesis and BMAD reviewer rewrite |
+| Implementation readiness | `implementation-readiness` | `implementation-readiness.md` | Complete, local synthesis and BMAD reviewer rewrite |
 
 ## Validation Rounds
 
 - Research: 1 local synthesis round after the first `analyst` subagent did not return a usable artifact before timeout.
-- Product brief: 1 local synthesis round after the `create-brief` subagent did not return a usable artifact before timeout.
+- Product brief: 1 local synthesis round after the `create-brief` subagent did not return a usable brief before timeout.
 - PRD, architecture, epics, and readiness: 1 local synthesis round each, based on the finalized research and product brief.
+- Architecture rewrite: 1 BMAD architect review and 1 BMAD planning review to generalize from a Customer-only future state to a shared reusable foundation plus Customer first adopter.
 
 ## Local Validation
 
-- `make ci` was attempted from the worktree.
-- The run could not complete because Docker could not start the required Compose services: `all predefined address pools have been fully subnetted`.
-- The early CI checks also failed because the `php` service was not running.
+- `make ci` was attempted from the worktree during the planning PR.
+- The run could not complete in the earlier environment because Docker could not start the required Compose services: `all predefined address pools have been fully subnetted`.
+- A later BMAD review attempt also could not complete local CI because the Compose `php` service stayed unhealthy after a host port `80` conflict.
 - No production code was changed in this planning PR.
 
 ## Open Questions, Warnings, Blockers
 
-- Warning: the first `analyst` subagent was closed after it did not return a concise research draft. Planning continued from repository evidence gathered by the main agent.
-- Warning: the `create-brief` subagent was closed after it did not return a concise brief. Planning continued locally to avoid indefinite stall.
-- Blocker: local CI needs an available Docker network pool before `make ci` can run to completion.
+- Warning: early BMAD artifact subagents timed out, so planning continued from repository evidence gathered by the main agent.
+- Blocker: local CI needs healthy Docker Compose services before `make ci` can run to completion.
 - Open question: whether full arbitrary collection cache materialization belongs in issue #176 or a provider-level follow-up.
-- Open question: whether customer type/status mutations should gain domain events for full reference-data refresh triggering.
+- Open question: whether Customer type/status mutations should gain domain events for full reference-data refresh triggering.
 
 ## Recommended Next Step
 
-Use these planning specs to implement issue #176 in a separate implementation PR. The recommended first implementation scope is currently cached customer detail and email lookup refresh, plus declared policies for collection/reference families.
+Use these planning specs to implement issue #176 in a separate implementation PR. The recommended implementation scope is the shared reusable cache-refresh foundation, one shared `cache-refresh` queue and worker, and Customer as the first adopter for currently cached detail and email lookup families.

--- a/specs/issue-176-async-cache-refresh/run-summary.md
+++ b/specs/issue-176-async-cache-refresh/run-summary.md
@@ -26,6 +26,7 @@ Scope guard: This PR is planning-only and does not implement production code.
 - PRD, architecture, epics, and readiness: 1 local synthesis round each, based on the finalized research and product brief.
 - Architecture rewrite: 1 BMAD architect review and 1 BMAD planning review to generalize from a Customer-only future state to a shared reusable foundation plus Customer first adopter.
 - Post-review architecture update: 1 BMAD planning rewrite to make automatic CRUD invalidation a shared ODM listener concern, keep Domain repository interfaces cache-free, and model `repository_refresh`, `event_snapshot`, and `invalidate_only` refresh sources.
+- Layered invalidation update: 1 BMAD planning rewrite to require automatic invalidation from exposed domain events, ODM entity-change events, and repository fallback calls for custom writes that bypass ODM observation.
 
 ## Local Validation
 
@@ -33,6 +34,7 @@ Scope guard: This PR is planning-only and does not implement production code.
 - The run could not complete in the earlier environment because Docker could not start the required Compose services: `all predefined address pools have been fully subnetted`.
 - A later BMAD review attempt also could not complete local CI because the Compose `php` service stayed unhealthy after a host port `80` conflict.
 - A post-review docs-only `make ci` attempt hit the same local Docker blocker: the `php` service repeatedly became unhealthy during Compose startup.
+- The layered invalidation docs update hit the same blocker: Docker could not bind port `80` for the `php` service, then the `php` container repeatedly became unhealthy.
 - No production code was changed in this planning PR.
 
 ## Open Questions, Warnings, Blockers
@@ -40,10 +42,10 @@ Scope guard: This PR is planning-only and does not implement production code.
 - Warning: early BMAD artifact subagents timed out, so planning continued from repository evidence gathered by the main agent.
 - Blocker: local CI needs healthy Docker Compose services before `make ci` can run to completion.
 - Open question: whether full arbitrary collection cache materialization belongs in issue #176 or a provider-level follow-up.
-- Open question: whether Customer type/status mutations should gain domain events for full reference-data refresh triggering.
-- Open question: whether any production write path bypasses ODM UnitOfWork change sets and needs an explicit repository-level invalidation fallback.
+- Open question: whether Customer type/status mutations should gain domain events for business semantics beyond ODM-observed cache invalidation.
+- Open question: whether any production write path outside the currently reviewed repositories bypasses ODM UnitOfWork change sets and needs an explicit repository-level invalidation fallback.
 - Warning: current Customer events do not carry complete cache snapshots, so event-only refresh is deferred in favor of `repository_refresh`.
 
 ## Recommended Next Step
 
-Use these planning specs to implement issue #176 in a separate implementation PR. The recommended implementation scope is the shared reusable cache-refresh foundation, shared ODM automatic CRUD invalidation, one shared `cache-refresh` queue and worker, and Customer as the first adopter for currently cached detail and email lookup families.
+Use these planning specs to implement issue #176 in a separate implementation PR. The recommended implementation scope is the shared reusable cache-refresh foundation, shared domain-event invalidation, shared ODM automatic CRUD invalidation, repository fallback coverage for custom writes that bypass ODM observation, one shared `cache-refresh` queue and worker, and Customer as the first adopter for currently cached detail and email lookup families.

--- a/specs/issue-176-async-cache-refresh/run-summary.md
+++ b/specs/issue-176-async-cache-refresh/run-summary.md
@@ -1,0 +1,45 @@
+# Issue 176 BMALPH Planning Run
+
+Bundle source: `_bmad-output/planning-artifacts/autonomous/<issue-176-artifact-bundle>`
+
+Tracked spec directory: `specs/issue-176-async-cache-refresh`
+
+Task: Plan GitHub issue #176, "Implement endpoint cache invalidation with async background refresh via SQS workers".
+
+Scope guard: This PR is planning-only and does not implement production code.
+
+## Subagent Execution Log
+
+| Phase                    | BMALPH command             | Artifact                      | Status                                          |
+| ------------------------ | -------------------------- | ----------------------------- | ----------------------------------------------- |
+| Research                 | `analyst`                  | `research.md`                 | Complete, local recovery after subagent timeout |
+| Product brief            | `create-brief`             | `product-brief.md`            | Complete, local recovery after subagent timeout |
+| PRD                      | `create-prd`               | `prd.md`                      | Complete, local synthesis                       |
+| Architecture             | `create-architecture`      | `architecture.md`             | Complete, local synthesis                       |
+| Epics and stories        | `create-epics-stories`     | `epics.md`                    | Complete, local synthesis                       |
+| Implementation readiness | `implementation-readiness` | `implementation-readiness.md` | Complete, local synthesis                       |
+
+## Validation Rounds
+
+- Research: 1 local synthesis round after the first `analyst` subagent did not return a usable artifact before timeout.
+- Product brief: 1 local synthesis round after the `create-brief` subagent did not return a usable artifact before timeout.
+- PRD, architecture, epics, and readiness: 1 local synthesis round each, based on the finalized research and product brief.
+
+## Local Validation
+
+- `make ci` was attempted from the worktree.
+- The run could not complete because Docker could not start the required Compose services: `all predefined address pools have been fully subnetted`.
+- The early CI checks also failed because the `php` service was not running.
+- No production code was changed in this planning PR.
+
+## Open Questions, Warnings, Blockers
+
+- Warning: the first `analyst` subagent was closed after it did not return a concise research draft. Planning continued from repository evidence gathered by the main agent.
+- Warning: the `create-brief` subagent was closed after it did not return a concise brief. Planning continued locally to avoid indefinite stall.
+- Blocker: local CI needs an available Docker network pool before `make ci` can run to completion.
+- Open question: whether full arbitrary collection cache materialization belongs in issue #176 or a provider-level follow-up.
+- Open question: whether customer type/status mutations should gain domain events for full reference-data refresh triggering.
+
+## Recommended Next Step
+
+Use these planning specs to implement issue #176 in a separate implementation PR. The recommended first implementation scope is currently cached customer detail and email lookup refresh, plus declared policies for collection/reference families.

--- a/specs/issue-176-async-cache-refresh/run-summary.md
+++ b/specs/issue-176-async-cache-refresh/run-summary.md
@@ -25,12 +25,14 @@ Scope guard: This PR is planning-only and does not implement production code.
 - Product brief: 1 local synthesis round after the `create-brief` subagent did not return a usable brief before timeout.
 - PRD, architecture, epics, and readiness: 1 local synthesis round each, based on the finalized research and product brief.
 - Architecture rewrite: 1 BMAD architect review and 1 BMAD planning review to generalize from a Customer-only future state to a shared reusable foundation plus Customer first adopter.
+- Post-review architecture update: 1 BMAD planning rewrite to make automatic CRUD invalidation a shared ODM listener concern, keep Domain repository interfaces cache-free, and model `repository_refresh`, `event_snapshot`, and `invalidate_only` refresh sources.
 
 ## Local Validation
 
 - `make ci` was attempted from the worktree during the planning PR.
 - The run could not complete in the earlier environment because Docker could not start the required Compose services: `all predefined address pools have been fully subnetted`.
 - A later BMAD review attempt also could not complete local CI because the Compose `php` service stayed unhealthy after a host port `80` conflict.
+- A post-review docs-only `make ci` attempt hit the same local Docker blocker: the `php` service repeatedly became unhealthy during Compose startup.
 - No production code was changed in this planning PR.
 
 ## Open Questions, Warnings, Blockers
@@ -39,7 +41,9 @@ Scope guard: This PR is planning-only and does not implement production code.
 - Blocker: local CI needs healthy Docker Compose services before `make ci` can run to completion.
 - Open question: whether full arbitrary collection cache materialization belongs in issue #176 or a provider-level follow-up.
 - Open question: whether Customer type/status mutations should gain domain events for full reference-data refresh triggering.
+- Open question: whether any production write path bypasses ODM UnitOfWork change sets and needs an explicit repository-level invalidation fallback.
+- Warning: current Customer events do not carry complete cache snapshots, so event-only refresh is deferred in favor of `repository_refresh`.
 
 ## Recommended Next Step
 
-Use these planning specs to implement issue #176 in a separate implementation PR. The recommended implementation scope is the shared reusable cache-refresh foundation, one shared `cache-refresh` queue and worker, and Customer as the first adopter for currently cached detail and email lookup families.
+Use these planning specs to implement issue #176 in a separate implementation PR. The recommended implementation scope is the shared reusable cache-refresh foundation, shared ODM automatic CRUD invalidation, one shared `cache-refresh` queue and worker, and Customer as the first adopter for currently cached detail and email lookup families.


### PR DESCRIPTION
## Description

Adds planning-only BMALPH/BMAD specs for issue #176 under `specs/issue-176-async-cache-refresh`.

This PR now frames the feature as shared layered cache invalidation plus a reusable async cache-refresh foundation, with Customer as the first adopter. It intentionally does not implement the async cache refresh feature.

The planning bundle includes research, product brief, PRD, architecture notes with a Mermaid architecture diagram, a current-directory-aligned planned source tree, epics/stories, implementation readiness, and the planning run summary.

It also updates the AI-agent DDD/code-organization/cache-management skills so future agents inspect the current repository directory structure and deptrac collectors before proposing class names or directories, and so they model cache invalidation as layered explicit signals instead of domain-events-only.

## Related Issue

Related to #176

## Motivation and Context

This gives the implementation work a reviewed planning baseline before production code changes are made. BMAD Markdown planning artifacts are kept under the repository-root `specs/` directory.

The latest spec update covers every reliable invalidation signal:

- exposed domain events route through a shared `CacheInvalidationCommand`
- Doctrine MongoDB ODM flush/change-set events route through the same command
- custom repository methods that bypass ODM change-set observation must call the same command after successful writes
- duplicate signals are idempotent and refresh jobs use deterministic dedupe keys
- current custom Customer repository deletes are classified as ODM-observed because they load/remove managed documents and flush

Current Customer domain events are treated as invalidation/scheduling signals only, not as event snapshots, because they do not carry complete cacheable Customer payloads.

## Planned Source Tree

```text
src/
  Shared/
    Application/
      Command/
        CacheInvalidationCommand.php
        CacheRefreshCommand.php
      CommandHandler/
        CacheInvalidationCommandHandler.php
        AbstractCacheRefreshCommandHandler.php
        CacheRefreshCommandHandler.php
      DTO/
        CacheInvalidationRule.php
        CacheInvalidationTagSet.php
        CacheRefreshPolicy.php
        CacheRefreshResult.php
        CacheRefreshTarget.php
      EventSubscriber/
        AbstractCacheInvalidationSubscriber.php
      Factory/
        AbstractCacheRefreshCommandFactory.php
      Observability/
        Metric/
          CacheHitMetric.php
          CacheMissMetric.php
          CacheRefreshFailedMetric.php
          CacheRefreshScheduledMetric.php
          CacheRefreshStaleServedMetric.php
          CacheRefreshSucceededMetric.php
          ValueObject/
            CacheRefreshMetricDimensions.php
      Resolver/
        CacheRefreshCommandHandlerResolverInterface.php
        CacheRefreshPolicyResolverInterface.php
        CacheRefreshTargetResolverInterface.php
    Infrastructure/
      Cache/
        CacheKeyBuilder.php (existing, edit for generic context/family key helpers)
      Collection/
        CacheInvalidationRuleCollection.php
        CacheRefreshCommandHandlerCollection.php
        CacheRefreshPolicyCollection.php
        CacheRefreshTargetResolverCollection.php
      EventListener/
        CacheInvalidationDoctrineEventListener.php
      Resolver/
        CacheInvalidationTagResolver.php
        CacheRefreshCommandHandlerResolver.php
        CacheRefreshPolicyResolver.php
  Core/
    Customer/
      Application/
        CommandHandler/
          CustomerCacheRefreshCommandHandler.php
        EventSubscriber/
          CustomerCreatedCacheInvalidationSubscriber.php (edit)
          CustomerDeletedCacheInvalidationSubscriber.php (edit)
          CustomerUpdatedCacheInvalidationSubscriber.php (edit)
        Factory/
          CustomerCacheRefreshCommandFactory.php
      Infrastructure/
        Collection/
          CustomerCacheInvalidationRuleCollection.php
          CustomerCachePolicyCollection.php
          CustomerCacheTagCollection.php (existing)
        Repository/
          CachedCustomerRepository.php (edit)
          MongoCustomerRepository.php (review custom write methods for ODM visibility)
          MongoStatusRepository.php (review custom write methods for ODM visibility)
          MongoTypeRepository.php (review custom write methods for ODM visibility)
        Resolver/
          CustomerCacheInvalidationTagResolver.php
          CustomerCachePolicyResolver.php
          CustomerCacheRefreshTargetResolver.php
          CustomerCacheTagResolver.php (existing)
```

## How Tested

- `bmalph -C . doctor --json` passed 19/19 checks.
- `npx prettier --write specs/issue-176-async-cache-refresh/*.md .claude/skills/cache-management/SKILL.md .claude/skills/cache-management/reference/invalidation-strategies.md` completed.
- `git diff --check` passed locally.
- `make ci` was attempted locally, but local Docker could not run the PHP service: Docker could not bind port `80`, then the `php` container repeatedly became unhealthy during Compose startup. GitHub Actions is the authoritative full CI result for this PR.
- Thread-aware PR review read shows no unresolved, non-outdated review threads.
- GitHub Actions: all 44 checks passed on latest commit `b53aa788c2867542300f4fe7c2224ff601639d39`.

## Screenshots

N/A - documentation-only planning specs.

## Types of changes

- [ ] Bug fix
- [ ] New feature
- [x] Documentation/planning update
- [ ] Refactoring
- [x] Chore

## Checklist

- [x] My code follows the code style of this project. (N/A: docs-only)
- [x] I have performed a self-review of my own changes.
- [x] I have updated documentation accordingly.
- [x] I have added tests to cover my changes. (N/A: planning-only docs)
- [x] All new and existing tests passed in GitHub Actions on latest commit `b53aa788c2867542300f4fe7c2224ff601639d39`.
- [ ] This PR contains exactly one commit. (7 commits after review-fix commits; squash merge is expected if a single commit is required.)
- [x] Structurizr documentation is updated if architecture changed. (N/A: planning-only specs)
