### PR TITLE
fix: safeguard infinite retry strategy

### DIFF
--- a/.env
+++ b/.env
@@ -26,12 +26,14 @@ LOCALSTACK_PORT=4566
 # Queue names
 DOMAIN_EVENTS_QUEUE_NAME=domain-events
 FAILED_DOMAIN_EVENTS_QUEUE_NAME=failed-domain-events
+DEAD_DOMAIN_EVENTS_QUEUE_NAME=dead-domain-events
 CACHE_REFRESH_QUEUE_NAME=cache-refresh
 FAILED_CACHE_REFRESH_QUEUE_NAME=failed-cache-refresh
 
 # Transport DSNs
 DOMAIN_EVENTS_TRANSPORT_DSN=sqs://localstack:${LOCALSTACK_PORT}/${DOMAIN_EVENTS_QUEUE_NAME}?sslmode=disable&region=${AWS_SQS_REGION}&access_key=${AWS_SQS_KEY}&secret_key=${AWS_SQS_SECRET}
 FAILED_DOMAIN_EVENTS_TRANSPORT_DSN=sqs://localstack:${LOCALSTACK_PORT}/${FAILED_DOMAIN_EVENTS_QUEUE_NAME}?sslmode=disable&region=${AWS_SQS_REGION}&access_key=${AWS_SQS_KEY}&secret_key=${AWS_SQS_SECRET}
+DEAD_DOMAIN_EVENTS_TRANSPORT_DSN=sqs://localstack:${LOCALSTACK_PORT}/${DEAD_DOMAIN_EVENTS_QUEUE_NAME}?sslmode=disable&region=${AWS_SQS_REGION}&access_key=${AWS_SQS_KEY}&secret_key=${AWS_SQS_SECRET}
 CACHE_REFRESH_TRANSPORT_DSN=sqs://localstack:${LOCALSTACK_PORT}/${CACHE_REFRESH_QUEUE_NAME}?sslmode=disable&region=${AWS_SQS_REGION}&access_key=${AWS_SQS_KEY}&secret_key=${AWS_SQS_SECRET}
 FAILED_CACHE_REFRESH_TRANSPORT_DSN=sqs://localstack:${LOCALSTACK_PORT}/${FAILED_CACHE_REFRESH_QUEUE_NAME}?sslmode=disable&region=${AWS_SQS_REGION}&access_key=${AWS_SQS_KEY}&secret_key=${AWS_SQS_SECRET}
 

--- a/.env.test
+++ b/.env.test
@@ -18,6 +18,7 @@ LOAD_TEST_CONFIG=tests/Load/config.json.dist
 # These are placeholders to satisfy env var requirements
 DOMAIN_EVENTS_TRANSPORT_DSN=in-memory://
 FAILED_DOMAIN_EVENTS_TRANSPORT_DSN=in-memory://
+DEAD_DOMAIN_EVENTS_TRANSPORT_DSN=in-memory://
 CACHE_REFRESH_TRANSPORT_DSN=in-memory://
 FAILED_CACHE_REFRESH_TRANSPORT_DSN=in-memory://
 CUSTOMER_CACHE_DETAIL_TTL=600

--- a/composer.lock
+++ b/composer.lock
@@ -7027,16 +7027,16 @@
         },
         {
             "name": "webonyx/graphql-php",
-            "version": "v15.31.5",
+            "version": "v15.32.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/webonyx/graphql-php.git",
-                "reference": "089c4ef7e112df85788cfe06596278a8f99f4aa9"
+                "reference": "993bf0bea17f870412ad8a90f60c41cb8d5f1145"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/webonyx/graphql-php/zipball/089c4ef7e112df85788cfe06596278a8f99f4aa9",
-                "reference": "089c4ef7e112df85788cfe06596278a8f99f4aa9",
+                "url": "https://api.github.com/repos/webonyx/graphql-php/zipball/993bf0bea17f870412ad8a90f60c41cb8d5f1145",
+                "reference": "993bf0bea17f870412ad8a90f60c41cb8d5f1145",
                 "shasum": ""
             },
             "require": {
@@ -7045,16 +7045,16 @@
                 "php": "^7.4 || ^8"
             },
             "require-dev": {
-                "amphp/amp": "^2.6",
-                "amphp/http-server": "^2.1",
+                "amphp/amp": "^2.6 || ^3",
+                "amphp/http-server": "^2.1 || ^3",
                 "dms/phpunit-arraysubset-asserts": "dev-master",
                 "ergebnis/composer-normalize": "^2.28",
-                "friendsofphp/php-cs-fixer": "3.94.2",
+                "friendsofphp/php-cs-fixer": "3.95.1",
                 "mll-lab/php-cs-fixer-config": "5.13.0",
                 "nyholm/psr7": "^1.5",
                 "phpbench/phpbench": "^1.2",
                 "phpstan/extension-installer": "^1.1",
-                "phpstan/phpstan": "2.1.46",
+                "phpstan/phpstan": "2.1.51",
                 "phpstan/phpstan-phpunit": "2.0.16",
                 "phpstan/phpstan-strict-rules": "2.0.10",
                 "phpunit/phpunit": "^9.5 || ^10.5.21 || ^11",
@@ -7068,6 +7068,7 @@
                 "ticketswap/phpstan-error-formatter": "1.3.0"
             },
             "suggest": {
+                "amphp/amp": "To leverage async resolving on AMPHP platform (v3 with AmpFutureAdapter, v2 with AmpPromiseAdapter)",
                 "amphp/http-server": "To leverage async resolving with webserver on AMPHP platform",
                 "psr/http-message": "To use standard GraphQL server",
                 "react/promise": "To leverage async resolving on React PHP platform"
@@ -7090,7 +7091,7 @@
             ],
             "support": {
                 "issues": "https://github.com/webonyx/graphql-php/issues",
-                "source": "https://github.com/webonyx/graphql-php/tree/v15.31.5"
+                "source": "https://github.com/webonyx/graphql-php/tree/v15.32.3"
             },
             "funding": [
                 {
@@ -7102,7 +7103,7 @@
                     "type": "open_collective"
                 }
             ],
-            "time": "2026-04-11T18:06:15+00:00"
+            "time": "2026-04-24T13:49:35+00:00"
         },
         {
             "name": "willdurand/negotiation",

--- a/config/packages/messenger.yaml
+++ b/config/packages/messenger.yaml
@@ -28,6 +28,11 @@ framework:
         dsn: '%env(FAILED_DOMAIN_EVENTS_TRANSPORT_DSN)%'
         retry_strategy:
           service: 'App\Shared\Infrastructure\RetryStrategy\InfiniteRetryStrategy'
+        failure_transport: dead-domain-events
+
+      # Terminal DLQ for domain events that cannot be retried safely.
+      dead-domain-events:
+        dsn: '%env(DEAD_DOMAIN_EVENTS_TRANSPORT_DSN)%'
 
       # Shared async transport for proactive cache refresh work.
       cache-refresh:
@@ -62,5 +67,6 @@ when@test:
       transports:
         domain-events: 'in-memory://'
         failed-domain-events: 'in-memory://'
+        dead-domain-events: 'in-memory://'
         cache-refresh: 'in-memory://'
         failed-cache-refresh: 'in-memory://'

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -109,6 +109,7 @@ services:
   App\Shared\Infrastructure\RetryStrategy\InfiniteRetryStrategy:
     arguments:
       $delayMs: '%env(int:MESSENGER_RETRY_DELAY_MS)%'
+      $metricsEmitter: '@App\Shared\Application\Observability\Emitter\BusinessMetricsEmitterInterface'
 
   App\Shared\Infrastructure\EventListener\ApiNotFoundProblemListener:
     tags:

--- a/specs/autonomous/issue-94-infinite-retry-safeguards/architecture.md
+++ b/specs/autonomous/issue-94-infinite-retry-safeguards/architecture.md
@@ -1,0 +1,51 @@
+# Architecture: Infinite Retry Safeguards
+
+## Components
+
+### `InfiniteRetryStrategy`
+
+The existing Messenger retry strategy remains the integration point for `failed-domain-events`.
+
+Responsibilities added:
+
+- Walk the throwable chain.
+- Match throwable classes against the permanent failure taxonomy.
+- Emit retry or DLQ metrics.
+- Return the Messenger retry decision.
+
+### Metrics
+
+New business metrics use the existing observability model:
+
+- `RetryAttemptMetric`
+- `DlqRoutingMetric`
+- `RetryStrategyMetricDimensions`
+
+The metrics are intentionally small value objects. They do not depend on Messenger infrastructure and can be tested independently.
+
+### Messenger Transports
+
+Queue flow after the change:
+
+1. `domain-events`
+2. `failed-domain-events`
+3. `dead-domain-events`
+
+`dead-domain-events` is terminal. It exists for manual inspection, replay tooling, or operational remediation outside this PR.
+
+## Error Handling
+
+Metric emission is wrapped in a broad `Throwable` catch. Observability is useful but must not become part of the delivery contract for retry decisions.
+
+## CAP/AP Position
+
+The AP behavior is preserved for unknown and transient failures because they remain retryable indefinitely. The new permanent-failure path is only for deterministic failures where repeated retries cannot restore availability.
+
+## Extension Points
+
+Future work can add:
+
+- A dedicated exception marker interface for permanent message failures.
+- Replay tooling for `dead-domain-events`.
+- Circuit breaker controls around repeated transient failures.
+- Dashboards and alerts on `MessengerDlqRoutings`.

--- a/specs/autonomous/issue-94-infinite-retry-safeguards/epics.md
+++ b/specs/autonomous/issue-94-infinite-retry-safeguards/epics.md
@@ -1,0 +1,27 @@
+# Epics: Infinite Retry Safeguards
+
+## Epic 1: Retry Classification
+
+- Add permanent-failure taxonomy.
+- Inspect wrapped exceptions.
+- Preserve retry behavior for unknown failures.
+
+## Epic 2: Terminal DLQ
+
+- Add dead-domain-events transport.
+- Wire failed-domain-events to the terminal DLQ.
+- Add environment variables for local and test environments.
+
+## Epic 3: Observability
+
+- Add retry-attempt metric.
+- Add DLQ-routing metric.
+- Add dimensions for endpoint, operation, message type, and exception type.
+- Keep metrics best-effort.
+
+## Epic 4: Documentation And Verification
+
+- Document retry strategy behavior and taxonomy.
+- Add unit coverage for retryable, permanent, wrapped, and metrics-failure paths.
+- Add metric value-object tests.
+- Run focused tests and static checks.

--- a/specs/autonomous/issue-94-infinite-retry-safeguards/implementation-readiness.md
+++ b/specs/autonomous/issue-94-infinite-retry-safeguards/implementation-readiness.md
@@ -1,0 +1,34 @@
+# Implementation Readiness: Infinite Retry Safeguards
+
+## Readiness
+
+Ready for implementation.
+
+## Dependencies
+
+- Symfony Messenger retry strategy interface already exists in the application.
+- Business metrics infrastructure already exists.
+- Messenger transports are configured in `config/packages/messenger.yaml`.
+
+## Known Constraints
+
+- Unknown exceptions must stay retryable to preserve AP behavior.
+- The strategy service ID must stay stable because Messenger references it directly.
+- Metrics must not make retry decisions fail.
+- Test environment must define all new transport DSNs.
+
+## Test Plan
+
+- Unit test `InfiniteRetryStrategy` for retryable unknown exceptions.
+- Unit test transient transport exceptions.
+- Unit test permanent exception taxonomy.
+- Unit test wrapped permanent exceptions.
+- Unit test metrics-emitter failure handling.
+- Unit test retry and DLQ metric dimensions.
+- Lint Symfony container to verify constructor and transport config.
+- Run Psalm and PHPMD.
+- Run configuration validation.
+
+## Rollout Notes
+
+Deployments must provide `DEAD_DOMAIN_EVENTS_TRANSPORT_DSN`. Local development uses the new `DEAD_DOMAIN_EVENTS_QUEUE_NAME` value from `.env`.

--- a/specs/autonomous/issue-94-infinite-retry-safeguards/prd.md
+++ b/specs/autonomous/issue-94-infinite-retry-safeguards/prd.md
@@ -1,0 +1,50 @@
+# PRD: Infinite Retry Strategy Safeguards
+
+## Functional Requirements
+
+1. The retry strategy must classify permanent failures.
+2. Permanent failures must return `false` from `isRetryable()`.
+3. Transient and unknown failures must return `true` from `isRetryable()`.
+4. Wrapped permanent failures must be detected through the exception chain.
+5. The failed domain-event transport must have a terminal DLQ.
+6. Retryable decisions must emit a retry-attempt metric.
+7. Permanent-failure decisions must emit a DLQ-routing metric.
+8. Metrics emission failures must not change retry decisions.
+9. The taxonomy and transport flow must be documented.
+
+## Permanent Failure Taxonomy
+
+- Domain rule failures
+- Invalid input and argument failures
+- Invalid JSON or message decoding failures
+- Logic/programmer errors
+- Messenger and Symfony validation failures
+- Serializer failures
+- PHP type/value errors
+
+## Availability Requirement
+
+Unknown failures must remain retryable. The implementation must avoid turning a newly introduced transient exception into message loss.
+
+## Configuration Requirements
+
+- Add `DEAD_DOMAIN_EVENTS_TRANSPORT_DSN`.
+- Add `DEAD_DOMAIN_EVENTS_QUEUE_NAME` for local SQS-style configuration.
+- Configure `failed-domain-events.failure_transport` to `dead-domain-events`.
+- Configure the test environment with an in-memory `dead-domain-events` transport.
+
+## Observability Requirements
+
+`MessengerRetryAttempts` dimensions:
+
+- `Endpoint=Messenger`
+- `Operation=retry`
+- `MessageType`
+- `ExceptionType`
+
+`MessengerDlqRoutings` dimensions:
+
+- `Endpoint=Messenger`
+- `Operation=dlq`
+- `MessageType`
+- `ExceptionType`

--- a/specs/autonomous/issue-94-infinite-retry-safeguards/product-brief-distillate.md
+++ b/specs/autonomous/issue-94-infinite-retry-safeguards/product-brief-distillate.md
@@ -1,0 +1,20 @@
+# Product Brief Distillate: Infinite Retry Safeguards
+
+## Core Outcome
+
+Preserve AP behavior for recoverable async domain-event failures while preventing deterministic poison messages from retrying forever.
+
+## Minimal Viable Change
+
+- Classify permanent failures in `InfiniteRetryStrategy`.
+- Return `false` for permanent failures and `true` otherwise.
+- Add `dead-domain-events` as the terminal DLQ after `failed-domain-events`.
+- Emit one metric for retry attempts and one metric for DLQ routing.
+- Document the taxonomy next to the strategy.
+
+## Risk Controls
+
+- Unknown exceptions remain retryable by default.
+- Metrics failures are swallowed so observability cannot alter delivery behavior.
+- Tests cover direct and wrapped permanent failures.
+- The existing service ID remains unchanged for Messenger wiring.

--- a/specs/autonomous/issue-94-infinite-retry-safeguards/product-brief.md
+++ b/specs/autonomous/issue-94-infinite-retry-safeguards/product-brief.md
@@ -1,0 +1,34 @@
+# Product Brief: Infinite Retry Safeguards
+
+## Problem
+
+The failed-domain-events retry path can retry poison messages forever. This protects availability for transient failures, but it also hides permanent message defects and can consume worker capacity indefinitely.
+
+## Users
+
+- Backend developers diagnosing failed async domain events.
+- Operators monitoring queue health and dead-letter volume.
+- QA engineers validating retry behavior for permanent and transient failures.
+
+## Goals
+
+- Stop retrying deterministic permanent failures in the infinite retry strategy.
+- Continue retrying transient and unknown failures indefinitely.
+- Route permanent failures from `failed-domain-events` to a terminal DLQ.
+- Emit business metrics for retry attempts and DLQ routings.
+- Document the retry taxonomy and queue flow.
+
+## Non-Goals
+
+- Replace Messenger's retry system.
+- Add a full circuit breaker implementation in this PR.
+- Change the bounded retry policy on the primary `domain-events` transport.
+- Change cache refresh retry behavior.
+
+## Success Criteria
+
+- `InfiniteRetryStrategy::isRetryable()` returns `false` for permanent failures.
+- `InfiniteRetryStrategy::isRetryable()` returns `true` for transient and unknown failures.
+- Permanent failures on `failed-domain-events` route to `dead-domain-events`.
+- Retry and DLQ metric objects expose stable CloudWatch dimensions.
+- Focused unit tests, container lint, Psalm, PHPMD, and configuration validation pass.

--- a/specs/autonomous/issue-94-infinite-retry-safeguards/research.md
+++ b/specs/autonomous/issue-94-infinite-retry-safeguards/research.md
@@ -4,7 +4,7 @@
 
 - GitHub issue: VilnaCRM-Org/core-service#94, "Feature Request: InfiniteRetryStrategy Safeguards"
 - Base branch: `origin/main` at `3f3fed0393e7ccd7be9fba85eeb499237226715c`
-- Worktree: `/home/kravtsov/Projects/core-service-issue-94`
+- Worktree: local development worktree (path omitted)
 - Branch: `fix/issue-94-infinite-retry-safeguards`
 
 ## Current State On Main

--- a/specs/autonomous/issue-94-infinite-retry-safeguards/research.md
+++ b/specs/autonomous/issue-94-infinite-retry-safeguards/research.md
@@ -1,0 +1,51 @@
+# Research: Issue 94 Infinite Retry Safeguards
+
+## Source
+
+- GitHub issue: VilnaCRM-Org/core-service#94, "Feature Request: InfiniteRetryStrategy Safeguards"
+- Base branch: `origin/main` at `3f3fed0393e7ccd7be9fba85eeb499237226715c`
+- Worktree: `/home/kravtsov/Projects/core-service-issue-94`
+- Branch: `fix/issue-94-infinite-retry-safeguards`
+
+## Current State On Main
+
+`InfiniteRetryStrategy` is configured for the `failed-domain-events` Messenger transport. It currently returns `true` for every throwable and therefore retries every failed message forever with a fixed delay.
+
+Main already has a two-stage domain event queue flow:
+
+- `domain-events` has bounded retries and routes exhausted messages to `failed-domain-events`.
+- `failed-domain-events` uses `InfiniteRetryStrategy`.
+- `failed-domain-events` had no terminal failure transport.
+
+The observability model is already present through `BusinessMetric`, `BusinessMetricsEmitterInterface`, and existing EMF infrastructure. That makes retry/DLQ metrics a local extension rather than a new observability stack.
+
+## Gap
+
+The current implementation cannot distinguish transient failures from permanent poison messages. Validation, decoding, schema, and type errors can retry forever even though retrying them is unlikely to make progress.
+
+The queue topology also lacks a terminal DLQ for failures that the infinite retry strategy decides are unsafe to retry.
+
+## Exception Taxonomy
+
+Permanent failures should include exceptions that represent deterministic payload, schema, programmer, or validation defects:
+
+- `DomainException`
+- `InvalidArgumentException`
+- `JsonException`
+- `LogicException`
+- Messenger message decoding failures
+- Messenger validation failures
+- Symfony serializer failures
+- Symfony validator failures
+- `TypeError`
+- `ValueError`
+
+Transient or unknown failures should remain retryable to preserve AP behavior for infrastructure outages, transport failures, and temporary downstream unavailability.
+
+## Decision
+
+Keep the existing strategy service and add selective retry logic inside it. This preserves the current Messenger integration point while adding a permanent-failure branch that emits a DLQ metric and returns `false`.
+
+Add a terminal `dead-domain-events` transport as the failure transport for `failed-domain-events`. Messenger can then route non-retryable poison messages to a queue instead of dropping them.
+
+Metric emission is best effort. Retry decisions must not depend on the metrics backend.

--- a/specs/autonomous/issue-94-infinite-retry-safeguards/run-summary.md
+++ b/specs/autonomous/issue-94-infinite-retry-safeguards/run-summary.md
@@ -1,0 +1,52 @@
+# Run Summary: Issue 94 Infinite Retry Safeguards
+
+## BMALPH Evidence
+
+- `bmalph --version`: 2.11.0
+- `make bmalph-init BMALPH_PLATFORM=codex BMALPH_DRY_RUN=true`: passed, project already initialized.
+- `bmalph upgrade --force`: completed; generated wrapper drift was restored before implementation.
+- `bmalph doctor`: 19 passed, all checks OK.
+
+## Implementation Summary
+
+Updated `InfiniteRetryStrategy` to classify permanent failures and preserve infinite retry for transient or unknown failures.
+
+Added permanent-failure routing:
+
+- `failed-domain-events` now has `failure_transport: dead-domain-events`.
+- `dead-domain-events` is configured as a terminal transport.
+- `.env` and `.env.test` define the new DLQ DSN.
+
+Added observability:
+
+- `RetryAttemptMetric`
+- `DlqRoutingMetric`
+- `RetryStrategyMetricDimensions`
+
+Added retry strategy documentation in `src/Shared/Infrastructure/RetryStrategy/README.md`.
+
+## Verification
+
+- Syntax check for touched PHP files: passed.
+- Focused PHPUnit:
+  - 20 tests
+  - 147 assertions
+  - passed
+- Symfony test container lint:
+  - passed
+- `php-cs-fixer --dry-run --diff` for touched PHP files:
+  - passed, 0 fixable files
+- Psalm:
+  - passed, no errors found
+- PHPMD:
+  - passed, no violations
+  - vendor deprecation notices were emitted by PHPMD/PDepend under PHP 8.4
+- `make validate-configuration`:
+  - passed
+  - warning: `.git` is a worktree file, so git modification checks were skipped
+- `git diff --check`:
+  - passed
+
+## Notes
+
+The issue listed circuit breaker safeguards as optional. This PR does not add a circuit breaker because selective permanent-failure routing and terminal DLQ support address the poison-message failure mode directly while keeping the change narrowly scoped.

--- a/src/Shared/Application/Observability/Metric/DlqRoutingMetric.php
+++ b/src/Shared/Application/Observability/Metric/DlqRoutingMetric.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Shared\Application\Observability\Metric;
+
+use App\Shared\Application\Observability\Metric\ValueObject\MetricUnit;
+use App\Shared\Application\Observability\Metric\ValueObject\RetryStrategyMetricDimensions;
+
+final readonly class DlqRoutingMetric extends BusinessMetric
+{
+    private function __construct(
+        private string $messageType,
+        private string $exceptionType,
+        float|int $value = 1
+    ) {
+        parent::__construct($value, new MetricUnit(MetricUnit::COUNT));
+    }
+
+    public static function create(
+        string $messageType,
+        string $exceptionType,
+        float|int $value = 1
+    ): self {
+        return new self($messageType, $exceptionType, $value);
+    }
+
+    public function name(): string
+    {
+        return 'MessengerDlqRoutings';
+    }
+
+    public function dimensions(): RetryStrategyMetricDimensions
+    {
+        return new RetryStrategyMetricDimensions(
+            operation: 'dlq',
+            messageType: $this->messageType,
+            exceptionType: $this->exceptionType
+        );
+    }
+}

--- a/src/Shared/Application/Observability/Metric/RetryAttemptMetric.php
+++ b/src/Shared/Application/Observability/Metric/RetryAttemptMetric.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Shared\Application\Observability\Metric;
+
+use App\Shared\Application\Observability\Metric\ValueObject\MetricUnit;
+use App\Shared\Application\Observability\Metric\ValueObject\RetryStrategyMetricDimensions;
+
+final readonly class RetryAttemptMetric extends BusinessMetric
+{
+    private function __construct(
+        private string $messageType,
+        private string $exceptionType,
+        float|int $value = 1
+    ) {
+        parent::__construct($value, new MetricUnit(MetricUnit::COUNT));
+    }
+
+    public static function create(
+        string $messageType,
+        string $exceptionType,
+        float|int $value = 1
+    ): self {
+        return new self($messageType, $exceptionType, $value);
+    }
+
+    public function name(): string
+    {
+        return 'MessengerRetryAttempts';
+    }
+
+    public function dimensions(): RetryStrategyMetricDimensions
+    {
+        return new RetryStrategyMetricDimensions(
+            operation: 'retry',
+            messageType: $this->messageType,
+            exceptionType: $this->exceptionType
+        );
+    }
+}

--- a/src/Shared/Application/Observability/Metric/ValueObject/RetryStrategyMetricDimensions.php
+++ b/src/Shared/Application/Observability/Metric/ValueObject/RetryStrategyMetricDimensions.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Shared\Application\Observability\Metric\ValueObject;
+
+use App\Shared\Application\Observability\Metric\Collection\MetricDimensions;
+
+final readonly class RetryStrategyMetricDimensions implements MetricDimensionsInterface
+{
+    public function __construct(
+        private string $operation,
+        private string $messageType,
+        private string $exceptionType
+    ) {
+    }
+
+    public function values(): MetricDimensions
+    {
+        return new MetricDimensions(
+            new MetricDimension('Endpoint', 'Messenger'),
+            new MetricDimension('Operation', $this->operation),
+            new MetricDimension('MessageType', $this->extractClassName($this->messageType)),
+            new MetricDimension('ExceptionType', $this->extractClassName($this->exceptionType))
+        );
+    }
+
+    private function extractClassName(string $fqcn): string
+    {
+        $parts = explode('\\', $fqcn);
+
+        return end($parts);
+    }
+}

--- a/src/Shared/Infrastructure/RetryStrategy/InfiniteRetryStrategy.php
+++ b/src/Shared/Infrastructure/RetryStrategy/InfiniteRetryStrategy.php
@@ -17,7 +17,6 @@ use Symfony\Component\Messenger\Envelope;
 use Symfony\Component\Messenger\Exception\MessageDecodingFailedException;
 use Symfony\Component\Messenger\Exception\ValidationFailedException as MessengerValidationFailure;
 use Symfony\Component\Messenger\Retry\RetryStrategyInterface;
-use Symfony\Component\Serializer\Exception\ExceptionInterface as SerializerExceptionInterface;
 use Symfony\Component\Validator\Exception\ValidationFailedException as ValidatorValidationFailure;
 use Symfony\Contracts\HttpClient\Exception\TransportExceptionInterface;
 use Throwable;
@@ -36,7 +35,7 @@ final class InfiniteRetryStrategy implements RetryStrategyInterface
         LogicException::class,
         MessageDecodingFailedException::class,
         MessengerValidationFailure::class,
-        SerializerExceptionInterface::class,
+        \Symfony\Component\Serializer\Exception\ExceptionInterface::class,
         TypeError::class,
         ValidatorValidationFailure::class,
         ValueError::class,

--- a/src/Shared/Infrastructure/RetryStrategy/InfiniteRetryStrategy.php
+++ b/src/Shared/Infrastructure/RetryStrategy/InfiniteRetryStrategy.php
@@ -15,10 +15,10 @@ use LogicException;
 use Symfony\Component\HttpClient\Response\AsyncContext;
 use Symfony\Component\Messenger\Envelope;
 use Symfony\Component\Messenger\Exception\MessageDecodingFailedException;
-use Symfony\Component\Messenger\Exception\ValidationFailedException as MessengerValidationFailedException;
+use Symfony\Component\Messenger\Exception\ValidationFailedException as MessengerValidationFailure;
 use Symfony\Component\Messenger\Retry\RetryStrategyInterface;
 use Symfony\Component\Serializer\Exception\ExceptionInterface as SerializerExceptionInterface;
-use Symfony\Component\Validator\Exception\ValidationFailedException as ValidatorValidationFailedException;
+use Symfony\Component\Validator\Exception\ValidationFailedException as ValidatorValidationFailure;
 use Symfony\Contracts\HttpClient\Exception\TransportExceptionInterface;
 use Throwable;
 use TypeError;
@@ -35,10 +35,10 @@ final class InfiniteRetryStrategy implements RetryStrategyInterface
         JsonException::class,
         LogicException::class,
         MessageDecodingFailedException::class,
-        MessengerValidationFailedException::class,
+        MessengerValidationFailure::class,
         SerializerExceptionInterface::class,
         TypeError::class,
-        ValidatorValidationFailedException::class,
+        ValidatorValidationFailure::class,
         ValueError::class,
     ];
 
@@ -68,8 +68,9 @@ final class InfiniteRetryStrategy implements RetryStrategyInterface
         Envelope $message,
         ?Throwable $throwable = null
     ): bool {
-        if ($this->containsPermanentFailure($throwable)) {
-            $this->emitDlqRouting($message, $throwable);
+        $permanentFailure = $this->permanentFailure($throwable);
+        if ($permanentFailure instanceof Throwable) {
+            $this->emitDlqRouting($message, $permanentFailure);
 
             return false;
         }
@@ -86,17 +87,17 @@ final class InfiniteRetryStrategy implements RetryStrategyInterface
         return $this->delayMs;
     }
 
-    private function containsPermanentFailure(?Throwable $throwable): bool
+    private function permanentFailure(?Throwable $throwable): ?Throwable
     {
         while ($throwable instanceof Throwable) {
             if ($this->isPermanentFailure($throwable)) {
-                return true;
+                return $throwable;
             }
 
             $throwable = $throwable->getPrevious();
         }
 
-        return false;
+        return null;
     }
 
     private function isPermanentFailure(Throwable $throwable): bool
@@ -122,7 +123,7 @@ final class InfiniteRetryStrategy implements RetryStrategyInterface
     {
         $this->emitMetric(DlqRoutingMetric::create(
             $this->messageType($message),
-            $this->exceptionType($throwable)
+            $this->matchedExceptionType($throwable)
         ));
     }
 
@@ -132,6 +133,7 @@ final class InfiniteRetryStrategy implements RetryStrategyInterface
             $this->metricsEmitter->emit($metric);
         } catch (Throwable) {
             // Retry decisions must not depend on observability availability.
+            return;
         }
     }
 
@@ -145,6 +147,11 @@ final class InfiniteRetryStrategy implements RetryStrategyInterface
         $rootCause = $this->rootCause($throwable);
 
         return $rootCause instanceof Throwable ? $rootCause::class : 'None';
+    }
+
+    private function matchedExceptionType(?Throwable $throwable): string
+    {
+        return $throwable instanceof Throwable ? $throwable::class : 'None';
     }
 
     private function rootCause(?Throwable $throwable): ?Throwable

--- a/src/Shared/Infrastructure/RetryStrategy/InfiniteRetryStrategy.php
+++ b/src/Shared/Infrastructure/RetryStrategy/InfiniteRetryStrategy.php
@@ -4,15 +4,47 @@ declare(strict_types=1);
 
 namespace App\Shared\Infrastructure\RetryStrategy;
 
+use App\Shared\Application\Observability\Emitter\BusinessMetricsEmitterInterface;
+use App\Shared\Application\Observability\Metric\BusinessMetric;
+use App\Shared\Application\Observability\Metric\DlqRoutingMetric;
+use App\Shared\Application\Observability\Metric\RetryAttemptMetric;
+use DomainException;
+use InvalidArgumentException;
+use JsonException;
+use LogicException;
 use Symfony\Component\HttpClient\Response\AsyncContext;
 use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\Exception\MessageDecodingFailedException;
+use Symfony\Component\Messenger\Exception\ValidationFailedException as MessengerValidationFailedException;
 use Symfony\Component\Messenger\Retry\RetryStrategyInterface;
+use Symfony\Component\Serializer\Exception\ExceptionInterface as SerializerExceptionInterface;
+use Symfony\Component\Validator\Exception\ValidationFailedException as ValidatorValidationFailedException;
 use Symfony\Contracts\HttpClient\Exception\TransportExceptionInterface;
+use Throwable;
+use TypeError;
+use ValueError;
 
 final class InfiniteRetryStrategy implements RetryStrategyInterface
 {
+    /**
+     * @var list<class-string<Throwable>>
+     */
+    private const PERMANENT_FAILURES = [
+        DomainException::class,
+        InvalidArgumentException::class,
+        JsonException::class,
+        LogicException::class,
+        MessageDecodingFailedException::class,
+        MessengerValidationFailedException::class,
+        SerializerExceptionInterface::class,
+        TypeError::class,
+        ValidatorValidationFailedException::class,
+        ValueError::class,
+    ];
+
     public function __construct(
         private readonly int $delayMs,
+        private readonly BusinessMetricsEmitterInterface $metricsEmitter,
     ) {
     }
 
@@ -34,15 +66,93 @@ final class InfiniteRetryStrategy implements RetryStrategyInterface
 
     public function isRetryable(
         Envelope $message,
-        ?\Throwable $throwable = null
+        ?Throwable $throwable = null
     ): bool {
+        if ($this->containsPermanentFailure($throwable)) {
+            $this->emitDlqRouting($message, $throwable);
+
+            return false;
+        }
+
+        $this->emitRetryAttempt($message, $throwable);
+
         return true;
     }
 
     public function getWaitingTime(
         Envelope $message,
-        ?\Throwable $throwable = null
+        ?Throwable $throwable = null
     ): int {
         return $this->delayMs;
+    }
+
+    private function containsPermanentFailure(?Throwable $throwable): bool
+    {
+        while ($throwable instanceof Throwable) {
+            if ($this->isPermanentFailure($throwable)) {
+                return true;
+            }
+
+            $throwable = $throwable->getPrevious();
+        }
+
+        return false;
+    }
+
+    private function isPermanentFailure(Throwable $throwable): bool
+    {
+        foreach (self::PERMANENT_FAILURES as $permanentFailure) {
+            if ($throwable instanceof $permanentFailure) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private function emitRetryAttempt(Envelope $message, ?Throwable $throwable): void
+    {
+        $this->emitMetric(RetryAttemptMetric::create(
+            $this->messageType($message),
+            $this->exceptionType($throwable)
+        ));
+    }
+
+    private function emitDlqRouting(Envelope $message, ?Throwable $throwable): void
+    {
+        $this->emitMetric(DlqRoutingMetric::create(
+            $this->messageType($message),
+            $this->exceptionType($throwable)
+        ));
+    }
+
+    private function emitMetric(BusinessMetric $metric): void
+    {
+        try {
+            $this->metricsEmitter->emit($metric);
+        } catch (Throwable) {
+            // Retry decisions must not depend on observability availability.
+        }
+    }
+
+    private function messageType(Envelope $message): string
+    {
+        return $message->getMessage()::class;
+    }
+
+    private function exceptionType(?Throwable $throwable): string
+    {
+        $rootCause = $this->rootCause($throwable);
+
+        return $rootCause instanceof Throwable ? $rootCause::class : 'None';
+    }
+
+    private function rootCause(?Throwable $throwable): ?Throwable
+    {
+        while ($throwable?->getPrevious() instanceof Throwable) {
+            $throwable = $throwable->getPrevious();
+        }
+
+        return $throwable;
     }
 }

--- a/src/Shared/Infrastructure/RetryStrategy/README.md
+++ b/src/Shared/Infrastructure/RetryStrategy/README.md
@@ -1,0 +1,56 @@
+# Retry Strategy
+
+`InfiniteRetryStrategy` is used on the `failed-domain-events` transport. It preserves availability for transient failures while preventing permanent poison messages from cycling forever.
+
+## Transport Flow
+
+1. `domain-events` handles async domain events.
+2. After the normal retry policy is exhausted, messages move to `failed-domain-events`.
+3. `failed-domain-events` uses `InfiniteRetryStrategy`.
+4. If the failure is classified as permanent, the message is not retried and Messenger routes it to `dead-domain-events`.
+
+## Transient Failures
+
+Transient failures continue to retry indefinitely with the configured delay. Examples:
+
+- SQS or network transport failures
+- Service unavailable responses
+- Timeout-like infrastructure failures
+- Unknown runtime exceptions without a permanent root cause
+
+Unknown exceptions are treated as retryable by default to preserve AP behavior.
+
+## Permanent Failures
+
+Permanent failures are not retried. They are routed to the terminal DLQ because retrying them is not expected to make progress.
+
+Current permanent taxonomy:
+
+- `DomainException`
+- `InvalidArgumentException`
+- `JsonException`
+- `LogicException`
+- `MessageDecodingFailedException`
+- Messenger validation failures
+- Symfony serializer exceptions
+- Symfony validator failures
+- `TypeError`
+- `ValueError`
+
+Wrapped failures are inspected through the exception chain, so a `HandlerFailedException` caused by a `TypeError` is treated as permanent.
+
+## Observability
+
+The strategy emits business metrics through `BusinessMetricsEmitterInterface`:
+
+- `MessengerRetryAttempts` for retryable failures
+- `MessengerDlqRoutings` for permanent failures routed to DLQ
+
+Metric dimensions:
+
+- `Endpoint=Messenger`
+- `Operation=retry` or `Operation=dlq`
+- `MessageType`
+- `ExceptionType`
+
+Metric emission is best effort. A metrics backend failure never changes the retry decision.

--- a/tests/Unit/Shared/Application/Observability/Metric/RetryStrategyMetricTest.php
+++ b/tests/Unit/Shared/Application/Observability/Metric/RetryStrategyMetricTest.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Shared\Application\Observability\Metric;
+
+use App\Shared\Application\Observability\Metric\DlqRoutingMetric;
+use App\Shared\Application\Observability\Metric\RetryAttemptMetric;
+use App\Shared\Application\Observability\Metric\ValueObject\MetricUnit;
+use App\Tests\Unit\UnitTestCase;
+
+final class RetryStrategyMetricTest extends UnitTestCase
+{
+    public function testRetryAttemptMetricUsesRetryDimensions(): void
+    {
+        $metric = RetryAttemptMetric::create(
+            'App\Message\DomainEventEnvelope',
+            'RuntimeException'
+        );
+
+        self::assertSame('MessengerRetryAttempts', $metric->name());
+        self::assertSame(1, $metric->value());
+        self::assertSame(MetricUnit::COUNT, $metric->unit()->value());
+        self::assertSame('Messenger', $metric->dimensions()->values()->get('Endpoint'));
+        self::assertSame('retry', $metric->dimensions()->values()->get('Operation'));
+        self::assertSame(
+            'DomainEventEnvelope',
+            $metric->dimensions()->values()->get('MessageType')
+        );
+        self::assertSame(
+            'RuntimeException',
+            $metric->dimensions()->values()->get('ExceptionType')
+        );
+    }
+
+    public function testDlqRoutingMetricUsesDlqDimensions(): void
+    {
+        $metric = DlqRoutingMetric::create(
+            'App\Message\DomainEventEnvelope',
+            'TypeError',
+            2
+        );
+
+        self::assertSame('MessengerDlqRoutings', $metric->name());
+        self::assertSame(2, $metric->value());
+        self::assertSame(MetricUnit::COUNT, $metric->unit()->value());
+        self::assertSame('Messenger', $metric->dimensions()->values()->get('Endpoint'));
+        self::assertSame('dlq', $metric->dimensions()->values()->get('Operation'));
+        self::assertSame(
+            'DomainEventEnvelope',
+            $metric->dimensions()->values()->get('MessageType')
+        );
+        self::assertSame('TypeError', $metric->dimensions()->values()->get('ExceptionType'));
+    }
+}

--- a/tests/Unit/Shared/Infrastructure/RetryStrategy/InfiniteRetryStrategyTest.php
+++ b/tests/Unit/Shared/Infrastructure/RetryStrategy/InfiniteRetryStrategyTest.php
@@ -111,6 +111,24 @@ final class InfiniteRetryStrategyTest extends UnitTestCase
         );
     }
 
+    public function testRetryMetricReportsRootCauseForWrappedRetryableException(): void
+    {
+        $rootCause = new \Exception('connection reset');
+        $throwable = new RuntimeException('handler failed', 0, $rootCause);
+
+        $this->assertTrue($this->retryStrategy->isRetryable(
+            $this->envelope(),
+            $throwable
+        ));
+
+        $this->assertEmittedMetric(
+            RetryAttemptMetric::class,
+            'MessengerRetryAttempts',
+            'retry',
+            \Exception::class
+        );
+    }
+
     public function testIsRetryableReturnsTrueWithoutThrowable(): void
     {
         $this->assertTrue($this->retryStrategy->isRetryable($this->envelope()));

--- a/tests/Unit/Shared/Infrastructure/RetryStrategy/InfiniteRetryStrategyTest.php
+++ b/tests/Unit/Shared/Infrastructure/RetryStrategy/InfiniteRetryStrategyTest.php
@@ -204,6 +204,25 @@ final class InfiniteRetryStrategyTest extends UnitTestCase
         );
     }
 
+    public function testDlqMetricReportsMatchedPermanentFailure(): void
+    {
+        $rootCause = new RuntimeException('database unavailable');
+        $permanentFailure = new DomainException('Domain rule failed', 0, $rootCause);
+        $throwable = new RuntimeException('handler failed', 0, $permanentFailure);
+
+        $this->assertFalse($this->retryStrategy->isRetryable(
+            $this->envelope(),
+            $throwable
+        ));
+
+        $this->assertEmittedMetric(
+            DlqRoutingMetric::class,
+            'MessengerDlqRoutings',
+            'dlq',
+            DomainException::class
+        );
+    }
+
     public function testMetricsFailureDoesNotChangeRetryDecision(): void
     {
         $this->metricsEmitter->failOnNextCall();

--- a/tests/Unit/Shared/Infrastructure/RetryStrategy/InfiniteRetryStrategyTest.php
+++ b/tests/Unit/Shared/Infrastructure/RetryStrategy/InfiniteRetryStrategyTest.php
@@ -4,22 +4,45 @@ declare(strict_types=1);
 
 namespace App\Tests\Unit\Shared\Infrastructure\RetryStrategy;
 
+use App\Shared\Application\Observability\Metric\DlqRoutingMetric;
+use App\Shared\Application\Observability\Metric\RetryAttemptMetric;
 use App\Shared\Infrastructure\RetryStrategy\InfiniteRetryStrategy;
+use App\Tests\Unit\Shared\Infrastructure\Observability\BusinessMetricsEmitterSpy;
 use App\Tests\Unit\UnitTestCase;
+use DomainException;
+use InvalidArgumentException;
+use JsonException;
+use LogicException;
+use RuntimeException;
 use Symfony\Component\HttpClient\Response\AsyncContext;
 use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\Exception\HandlerFailedException;
+use Symfony\Component\Messenger\Exception\MessageDecodingFailedException;
+use Symfony\Component\Messenger\Exception\ValidationFailedException as MessengerValidationFailedException;
+use Symfony\Component\Serializer\Exception\NotEncodableValueException;
+use Symfony\Component\Validator\ConstraintViolationListInterface;
+use Symfony\Component\Validator\Exception\ValidationFailedException as ValidatorValidationFailedException;
+use Symfony\Contracts\HttpClient\Exception\TransportExceptionInterface;
+use Throwable;
+use TypeError;
+use ValueError;
 
 final class InfiniteRetryStrategyTest extends UnitTestCase
 {
     private const int DELAY_MS = 60000;
 
     private InfiniteRetryStrategy $retryStrategy;
+    private BusinessMetricsEmitterSpy $metricsEmitter;
 
     protected function setUp(): void
     {
         parent::setUp();
 
-        $this->retryStrategy = new InfiniteRetryStrategy(self::DELAY_MS);
+        $this->metricsEmitter = new BusinessMetricsEmitterSpy();
+        $this->retryStrategy = new InfiniteRetryStrategy(
+            self::DELAY_MS,
+            $this->metricsEmitter
+        );
     }
 
     public function testShouldRetry(): void
@@ -55,20 +78,208 @@ final class InfiniteRetryStrategyTest extends UnitTestCase
         );
     }
 
-    public function testIsRetryable(): void
+    public function testIsRetryableReturnsTrueForUnknownException(): void
     {
-        $message = $this->createMock(Envelope::class);
+        $this->assertTrue($this->retryStrategy->isRetryable(
+            $this->envelope(),
+            new RuntimeException('backend unavailable')
+        ));
 
-        $this->assertTrue($this->retryStrategy->isRetryable($message));
+        $this->assertEmittedMetric(
+            RetryAttemptMetric::class,
+            'MessengerRetryAttempts',
+            'retry',
+            RuntimeException::class
+        );
+    }
+
+    public function testIsRetryableReturnsTrueForTransientTransportException(): void
+    {
+        $exception = new class('SQS timeout') extends RuntimeException implements TransportExceptionInterface {
+        };
+
+        $this->assertTrue($this->retryStrategy->isRetryable(
+            $this->envelope(),
+            $exception
+        ));
+
+        $this->assertEmittedMetric(
+            RetryAttemptMetric::class,
+            'MessengerRetryAttempts',
+            'retry',
+            $exception::class
+        );
+    }
+
+    public function testIsRetryableReturnsTrueWithoutThrowable(): void
+    {
+        $this->assertTrue($this->retryStrategy->isRetryable($this->envelope()));
+
+        $this->assertEmittedMetric(
+            RetryAttemptMetric::class,
+            'MessengerRetryAttempts',
+            'retry',
+            'None'
+        );
+    }
+
+    /**
+     * @dataProvider permanentFailureProvider
+     */
+    public function testIsRetryableReturnsFalseForPermanentFailure(
+        Throwable $throwable
+    ): void {
+        $this->assertFalse($this->retryStrategy->isRetryable(
+            $this->envelope(),
+            $throwable
+        ));
+
+        $this->assertEmittedMetric(
+            DlqRoutingMetric::class,
+            'MessengerDlqRoutings',
+            'dlq',
+            $throwable::class
+        );
+    }
+
+    public function testIsRetryableReturnsFalseForMessengerValidationFailure(): void
+    {
+        $violations = $this->createMock(ConstraintViolationListInterface::class);
+        $throwable = new MessengerValidationFailedException(
+            new \stdClass(),
+            $violations,
+            $this->envelope()
+        );
+
+        $this->assertFalse($this->retryStrategy->isRetryable(
+            $this->envelope(),
+            $throwable
+        ));
+
+        $this->assertEmittedMetric(
+            DlqRoutingMetric::class,
+            'MessengerDlqRoutings',
+            'dlq',
+            MessengerValidationFailedException::class
+        );
+    }
+
+    public function testIsRetryableReturnsFalseForValidatorFailure(): void
+    {
+        $violations = $this->createMock(ConstraintViolationListInterface::class);
+        $violations->method('__toString')->willReturn('Invalid message');
+        $throwable = new ValidatorValidationFailedException(
+            new \stdClass(),
+            $violations
+        );
+
+        $this->assertFalse($this->retryStrategy->isRetryable(
+            $this->envelope(),
+            $throwable
+        ));
+
+        $this->assertEmittedMetric(
+            DlqRoutingMetric::class,
+            'MessengerDlqRoutings',
+            'dlq',
+            ValidatorValidationFailedException::class
+        );
+    }
+
+    public function testIsRetryableInspectsWrappedPermanentFailure(): void
+    {
+        $wrapped = new TypeError('Invalid event payload');
+        $throwable = new HandlerFailedException($this->envelope(), [$wrapped]);
+
+        $this->assertFalse($this->retryStrategy->isRetryable(
+            $this->envelope(),
+            $throwable
+        ));
+
+        $this->assertEmittedMetric(
+            DlqRoutingMetric::class,
+            'MessengerDlqRoutings',
+            'dlq',
+            TypeError::class
+        );
+    }
+
+    public function testMetricsFailureDoesNotChangeRetryDecision(): void
+    {
+        $this->metricsEmitter->failOnNextCall();
+
+        $this->assertTrue($this->retryStrategy->isRetryable(
+            $this->envelope(),
+            new RuntimeException('backend unavailable')
+        ));
+        $this->assertSame(0, $this->metricsEmitter->count());
+
+        $this->metricsEmitter->failOnNextCall();
+
+        $this->assertFalse($this->retryStrategy->isRetryable(
+            $this->envelope(),
+            new TypeError('Invalid payload')
+        ));
+
+        $this->assertSame(0, $this->metricsEmitter->count());
     }
 
     public function testGetWaitingTime(): void
     {
-        $message = $this->createMock(Envelope::class);
-
         $this->assertSame(
             self::DELAY_MS,
-            $this->retryStrategy->getWaitingTime($message)
+            $this->retryStrategy->getWaitingTime($this->envelope())
         );
+    }
+
+    /**
+     * @return iterable<string, array{0: Throwable}>
+     */
+    public static function permanentFailureProvider(): iterable
+    {
+        yield 'domain exception' => [new DomainException('Domain rule failed')];
+        yield 'invalid argument' => [new InvalidArgumentException('Invalid input')];
+        yield 'json exception' => [new JsonException('Invalid JSON')];
+        yield 'logic exception' => [new LogicException('Programmer error')];
+        yield 'message decoding' => [new MessageDecodingFailedException('Bad envelope')];
+        yield 'serializer exception' => [new NotEncodableValueException('Bad schema')];
+        yield 'type error' => [new TypeError('Wrong type')];
+        yield 'value error' => [new ValueError('Wrong value')];
+    }
+
+    private function envelope(): Envelope
+    {
+        return new Envelope(new \stdClass());
+    }
+
+    /**
+     * @param class-string $metricClass
+     */
+    private function assertEmittedMetric(
+        string $metricClass,
+        string $metricName,
+        string $operation,
+        string $exceptionType
+    ): void {
+        self::assertSame(1, $this->metricsEmitter->count());
+
+        $metric = $this->metricsEmitter->emitted()->all()[0];
+        self::assertInstanceOf($metricClass, $metric);
+        self::assertSame($metricName, $metric->name());
+        self::assertSame(1, $metric->value());
+        self::assertSame('Messenger', $metric->dimensions()->values()->get('Endpoint'));
+        self::assertSame($operation, $metric->dimensions()->values()->get('Operation'));
+        self::assertSame('stdClass', $metric->dimensions()->values()->get('MessageType'));
+        self::assertSame(
+            self::shortClassName($exceptionType),
+            $metric->dimensions()->values()->get('ExceptionType')
+        );
+    }
+
+    private static function shortClassName(string $className): string
+    {
+        $parts = explode('\\', $className);
+
+        return end($parts);
     }
 }


### PR DESCRIPTION
## Description

Adds safeguards to `InfiniteRetryStrategy` so permanent poison-message failures stop retrying forever while transient and unknown failures keep the existing AP retry behavior.

Changes included:

- Adds permanent failure taxonomy for domain, validation, decoding, serialization, type, and logic failures.
- Emits `MessengerRetryAttempts` and `MessengerDlqRoutings` business metrics.
- Adds terminal `dead-domain-events` transport after `failed-domain-events`.
- Documents the retry taxonomy and transport flow.
- Adds the BMAD planning bundle for issue #94.

## Related Issue

Closes #94

## Motivation and Context

`InfiniteRetryStrategy::isRetryable()` previously returned `true` for every exception, which means deterministic poison messages could retry indefinitely. The new behavior preserves infinite retry for recoverable failures, but routes known permanent failures to a terminal DLQ.

## How Has This Been Tested?

- Syntax check for touched PHP files: passed.
- Focused PHPUnit:
  - `tests/Unit/Shared/Infrastructure/RetryStrategy/InfiniteRetryStrategyTest.php`
  - `tests/Unit/Shared/Application/Observability/Metric/RetryStrategyMetricTest.php`
  - 20 tests, 147 assertions, passed
- Symfony test container lint: passed.
- `php-cs-fixer --dry-run --diff` for touched PHP files: passed.
- Psalm: passed, no errors found.
- PHPMD: passed, no violations. Vendor PHP 8.4 deprecation notices were emitted by PHPMD/PDepend.
- `make validate-configuration`: passed with the expected worktree `.git` warning.
- `git diff --check`: passed.
- `bmalph doctor`: 19 passed, all checks OK.

## Screenshots (if appropriate):

N/A

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project.
- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING.md**](https://github.com/VilnaCRM-Org/core-service/blob/main/CONTRIBUTING.md) document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] You have only one commit (if not, squash them into one commit).
- [ ] Structurizr documentation has been updated to reflect any architectural changes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents infinite retries for permanent failures by classifying exceptions (walking the cause chain) in `InfiniteRetryStrategy`, while keeping infinite retries for transient/unknown errors. Adds a terminal `dead-domain-events` DLQ, emits retry/DLQ metrics with root-cause and matched-permanent context, and updates `webonyx/graphql-php` to v15.32.3 (aligns with issue #94).

- **New Features**
  - Wire `failed-domain-events` to `dead-domain-events` via failure_transport.
  - Emit `MessengerRetryAttempts` (root-cause) and `MessengerDlqRoutings` (matched permanent); best-effort only.
  - Document retry taxonomy and queue flow.

- **Migration**
  - Set DEAD_DOMAIN_EVENTS_TRANSPORT_DSN and DEAD_DOMAIN_EVENTS_QUEUE_NAME.
  - Test env uses in-memory:// for dead-domain-events.

<sup>Written for commit 696fea3b24d4a68f0c432a9060fd2b3a019d4176. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

