### PR TITLE
docs: complete project documentation workflow

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -1,0 +1,14 @@
+name: Documentation
+
+on:
+  pull_request:
+
+jobs:
+  docs-check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Validate documentation
+        run: make docs-check

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -3,6 +3,9 @@ name: Documentation
 on:
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   docs-check:
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -47,6 +47,7 @@ infection.log
 summary.log
 .sandbox-poc/bin/
 /coverage/
+/build/
 .ralph/
 .ralph/logs/
 _bmad/

--- a/Makefile
+++ b/Makefile
@@ -105,6 +105,9 @@ BATS_ARGS ?=
 DOCKER_TTY_FLAG = $(if $(CI),-T,)
 BMALPH_PLATFORM ?= codex
 BMALPH_DRY_RUN ?= false
+DOCS_SOURCE_DIR ?= docs
+DOCS_BUILD_DIR ?= build/docs
+DOCS_PHPDOC_IMAGE ?= phpdoc/phpdoc:3
 LOAD_TEST_STACK_COMPOSE_FILE ?= docker-compose.yml:docker-compose.override.yml:docker-compose.load_test.override.yml
 LOAD_TEST_STACK_ENV = COMPOSE_FILE="$(LOAD_TEST_STACK_COMPOSE_FILE)" APP_DEBUG=0 FRANKENPHP_ENABLE_WATCH=0 FRANKENPHP_SITE_CONFIG= FRANKENPHP_WORKER_CONFIG=
 
@@ -152,6 +155,20 @@ bmalph-init: ## Initialize BMALPH for current project; set BMALPH_DRY_RUN=true t
 
 bmalph-setup: ## Install and initialize BMALPH for current project; defaults to BMALPH_PLATFORM=codex
 	@$(MAKE) bmalph-init BMALPH_PLATFORM="$(BMALPH_PLATFORM)" BMALPH_DRY_RUN="$(BMALPH_DRY_RUN)"
+
+docs: docs-check docs-api ## Validate docs and generate source API reference into build/docs
+
+docs-check: ## Validate documentation structure and local Markdown links
+	bash scripts/check-docs.sh
+
+docs-api: ## Generate PHP API reference with PHPDocumentor Docker image
+	mkdir -p "$(DOCS_BUILD_DIR)"
+	$(DOCKER) run --rm \
+		--user "$$(id -u):$$(id -g)" \
+		-v "$(CURDIR)":/data \
+		-w /data \
+		$(DOCS_PHPDOC_IMAGE) \
+		--config=phpdoc.dist.xml
 
 bats: ## Run tests for bash commands
 	$(BATS_BIN) $(BATS_ARGS) $(BATS_FILES)

--- a/Makefile
+++ b/Makefile
@@ -107,7 +107,7 @@ BMALPH_PLATFORM ?= codex
 BMALPH_DRY_RUN ?= false
 DOCS_SOURCE_DIR ?= docs
 DOCS_BUILD_DIR ?= build/docs
-DOCS_PHPDOC_IMAGE ?= phpdoc/phpdoc:3
+DOCS_PHPDOC_IMAGE ?= phpdoc/phpdoc:3.8.0
 LOAD_TEST_STACK_COMPOSE_FILE ?= docker-compose.yml:docker-compose.override.yml:docker-compose.load_test.override.yml
 LOAD_TEST_STACK_ENV = COMPOSE_FILE="$(LOAD_TEST_STACK_COMPOSE_FILE)" APP_DEBUG=0 FRANKENPHP_ENABLE_WATCH=0 FRANKENPHP_SITE_CONFIG= FRANKENPHP_WORKER_CONFIG=
 
@@ -155,6 +155,8 @@ bmalph-init: ## Initialize BMALPH for current project; set BMALPH_DRY_RUN=true t
 
 bmalph-setup: ## Install and initialize BMALPH for current project; defaults to BMALPH_PLATFORM=codex
 	@$(MAKE) bmalph-init BMALPH_PLATFORM="$(BMALPH_PLATFORM)" BMALPH_DRY_RUN="$(BMALPH_DRY_RUN)"
+
+.PHONY: docs docs-check docs-api
 
 docs: docs-check docs-api ## Validate docs and generate source API reference into build/docs
 

--- a/README.md
+++ b/README.md
@@ -218,11 +218,21 @@ up                           Start the docker hub (FrankenPHP, database, redis, 
 
 ## Documentation
 
-Start reading at the [GitHub wiki](https://github.com/VilnaCRM-Org/core-service/wiki). If you're having trouble, head for [the troubleshooting guide](https://github.com/VilnaCRM-Org/core-service/wiki/Troubleshooting) as it's frequently updated.
+Start with the maintained [documentation index](docs/README.md). It links to setup, architecture, API, database, testing, deployment, operations, troubleshooting, security, and release documentation.
 
-You can generate complete API-level documentation by running `phpdoc` in the top-level folder, and documentation will appear in the `docs` folder, though you'll need to have [PHPDocumentor](http://www.phpdoc.org) installed.
+To validate documentation structure and local Markdown links, run:
 
-If the documentation doesn't cover what you need, search the [many questions on Stack Overflow](http://stackoverflow.com/questions/tagged/vilnacrm), and before you ask a question, [read the troubleshooting guide](https://github.com/VilnaCRM-Org/core-service/wiki/Troubleshooting).
+```bash
+make docs-check
+```
+
+To validate the docs and generate the PHPDocumentor source API reference into `build/docs/phpdoc`, run:
+
+```bash
+make docs
+```
+
+The local API Platform documentation is available at `https://localhost/api/docs` when the stack is running. For common setup and CI issues, see [docs/troubleshooting.md](docs/troubleshooting.md).
 
 ## Tests
 

--- a/composer.lock
+++ b/composer.lock
@@ -7027,16 +7027,16 @@
         },
         {
             "name": "webonyx/graphql-php",
-            "version": "v15.31.5",
+            "version": "v15.32.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/webonyx/graphql-php.git",
-                "reference": "089c4ef7e112df85788cfe06596278a8f99f4aa9"
+                "reference": "993bf0bea17f870412ad8a90f60c41cb8d5f1145"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/webonyx/graphql-php/zipball/089c4ef7e112df85788cfe06596278a8f99f4aa9",
-                "reference": "089c4ef7e112df85788cfe06596278a8f99f4aa9",
+                "url": "https://api.github.com/repos/webonyx/graphql-php/zipball/993bf0bea17f870412ad8a90f60c41cb8d5f1145",
+                "reference": "993bf0bea17f870412ad8a90f60c41cb8d5f1145",
                 "shasum": ""
             },
             "require": {
@@ -7045,16 +7045,16 @@
                 "php": "^7.4 || ^8"
             },
             "require-dev": {
-                "amphp/amp": "^2.6",
-                "amphp/http-server": "^2.1",
+                "amphp/amp": "^2.6 || ^3",
+                "amphp/http-server": "^2.1 || ^3",
                 "dms/phpunit-arraysubset-asserts": "dev-master",
                 "ergebnis/composer-normalize": "^2.28",
-                "friendsofphp/php-cs-fixer": "3.94.2",
+                "friendsofphp/php-cs-fixer": "3.95.1",
                 "mll-lab/php-cs-fixer-config": "5.13.0",
                 "nyholm/psr7": "^1.5",
                 "phpbench/phpbench": "^1.2",
                 "phpstan/extension-installer": "^1.1",
-                "phpstan/phpstan": "2.1.46",
+                "phpstan/phpstan": "2.1.51",
                 "phpstan/phpstan-phpunit": "2.0.16",
                 "phpstan/phpstan-strict-rules": "2.0.10",
                 "phpunit/phpunit": "^9.5 || ^10.5.21 || ^11",
@@ -7068,6 +7068,7 @@
                 "ticketswap/phpstan-error-formatter": "1.3.0"
             },
             "suggest": {
+                "amphp/amp": "To leverage async resolving on AMPHP platform (v3 with AmpFutureAdapter, v2 with AmpPromiseAdapter)",
                 "amphp/http-server": "To leverage async resolving with webserver on AMPHP platform",
                 "psr/http-message": "To use standard GraphQL server",
                 "react/promise": "To leverage async resolving on React PHP platform"
@@ -7090,7 +7091,7 @@
             ],
             "support": {
                 "issues": "https://github.com/webonyx/graphql-php/issues",
-                "source": "https://github.com/webonyx/graphql-php/tree/v15.31.5"
+                "source": "https://github.com/webonyx/graphql-php/tree/v15.32.3"
             },
             "funding": [
                 {
@@ -7102,7 +7103,7 @@
                     "type": "open_collective"
                 }
             ],
-            "time": "2026-04-11T18:06:15+00:00"
+            "time": "2026-04-24T13:49:35+00:00"
         },
         {
             "name": "willdurand/negotiation",

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,60 @@
+# Core Service Documentation
+
+This directory is the maintained documentation hub for VilnaCRM Core Service. Start here when setting up the project, changing customer-domain behavior, operating the service, or reviewing API contracts.
+
+## Quick Navigation
+
+| Area | Document | Use it for |
+| --- | --- | --- |
+| Overview | [main.md](main.md) | Service purpose, design principles, and high-level capabilities |
+| Setup | [getting-started.md](getting-started.md) | Local prerequisites, Docker startup, and first-run checks |
+| Onboarding | [onboarding.md](onboarding.md) | New contributor workflow and learning path |
+| Architecture | [design-and-architecture.md](design-and-architecture.md) | DDD, CQRS, hexagonal architecture, and bounded contexts |
+| Development | [developer-guide.md](developer-guide.md) | Code layout, implementation patterns, and Deptrac usage |
+| API | [api-endpoints.md](api-endpoints.md) | REST, GraphQL, OpenAPI, and request examples |
+| Database | [database.md](database.md) | MongoDB collections, indexes, schema ownership, and migrations |
+| Testing | [testing.md](testing.md) | Unit, integration, Behat, mutation, load, and API tests |
+| Deployment | [deployment.md](deployment.md) | Environment setup, release steps, and runtime dependencies |
+| Operations | [operational.md](operational.md) | Runtime checks, security posture, and support operations |
+| Troubleshooting | [troubleshooting.md](troubleshooting.md) | Common local, CI, database, queue, and API issues |
+| Configuration | [advanced-configuration.md](advanced-configuration.md) | Environment variables and load-test configuration |
+| Security | [security.md](security.md) | Secure development and dependency practices |
+| Performance | [performance.md](performance.md) | Performance benchmarks and optimization notes |
+| Versioning | [versioning.md](versioning.md) | Version policy and deprecation expectations |
+| Releases | [release-notes.md](release-notes.md) | Release process and changelog usage |
+| Community | [community-and-support.md](community-and-support.md) | Support and issue reporting channels |
+| Glossary | [glossary.md](glossary.md) | Shared domain vocabulary and naming conventions |
+| Usage | [user-guide.md](user-guide.md) | API usage walkthroughs |
+| Licensing | [legal-and-licensing.md](legal-and-licensing.md) | License and third-party package notes |
+
+## Generated Documentation
+
+Run the documentation workflow from the repository root:
+
+```bash
+make docs-check
+make docs
+```
+
+`make docs-check` validates the required documentation files, root README entry point, local Markdown links, and trailing whitespace. CI runs this target for pull requests.
+
+`make docs` runs `docs-check` and then generates the source API reference with PHPDocumentor into `build/docs/phpdoc`. The generated output is intentionally not committed.
+
+## Live API Documentation
+
+When the local stack is running, API Platform exposes interactive documentation at:
+
+- REST/OpenAPI: `https://localhost/api/docs`
+- GraphQL: `https://localhost/api/graphql`
+
+Static API contract files used by CI live under `.github/openapi-spec/` and `.github/graphql-spec/`.
+
+## Updating Documentation
+
+Update documentation in the same pull request as the related code change when behavior, commands, configuration, API contracts, data ownership, or deployment expectations change.
+
+Before opening a PR, run:
+
+```bash
+make docs-check
+```

--- a/docs/README.md
+++ b/docs/README.md
@@ -4,28 +4,28 @@ This directory is the maintained documentation hub for VilnaCRM Core Service. St
 
 ## Quick Navigation
 
-| Area | Document | Use it for |
-| --- | --- | --- |
-| Overview | [main.md](main.md) | Service purpose, design principles, and high-level capabilities |
-| Setup | [getting-started.md](getting-started.md) | Local prerequisites, Docker startup, and first-run checks |
-| Onboarding | [onboarding.md](onboarding.md) | New contributor workflow and learning path |
-| Architecture | [design-and-architecture.md](design-and-architecture.md) | DDD, CQRS, hexagonal architecture, and bounded contexts |
-| Development | [developer-guide.md](developer-guide.md) | Code layout, implementation patterns, and Deptrac usage |
-| API | [api-endpoints.md](api-endpoints.md) | REST, GraphQL, OpenAPI, and request examples |
-| Database | [database.md](database.md) | MongoDB collections, indexes, schema ownership, and migrations |
-| Testing | [testing.md](testing.md) | Unit, integration, Behat, mutation, load, and API tests |
-| Deployment | [deployment.md](deployment.md) | Environment setup, release steps, and runtime dependencies |
-| Operations | [operational.md](operational.md) | Runtime checks, security posture, and support operations |
-| Troubleshooting | [troubleshooting.md](troubleshooting.md) | Common local, CI, database, queue, and API issues |
-| Configuration | [advanced-configuration.md](advanced-configuration.md) | Environment variables and load-test configuration |
-| Security | [security.md](security.md) | Secure development and dependency practices |
-| Performance | [performance.md](performance.md) | Performance benchmarks and optimization notes |
-| Versioning | [versioning.md](versioning.md) | Version policy and deprecation expectations |
-| Releases | [release-notes.md](release-notes.md) | Release process and changelog usage |
-| Community | [community-and-support.md](community-and-support.md) | Support and issue reporting channels |
-| Glossary | [glossary.md](glossary.md) | Shared domain vocabulary and naming conventions |
-| Usage | [user-guide.md](user-guide.md) | API usage walkthroughs |
-| Licensing | [legal-and-licensing.md](legal-and-licensing.md) | License and third-party package notes |
+| Area            | Document                                                 | Use it for                                                      |
+| --------------- | -------------------------------------------------------- | --------------------------------------------------------------- |
+| Overview        | [main.md](main.md)                                       | Service purpose, design principles, and high-level capabilities |
+| Setup           | [getting-started.md](getting-started.md)                 | Local prerequisites, Docker startup, and first-run checks       |
+| Onboarding      | [onboarding.md](onboarding.md)                           | New contributor workflow and learning path                      |
+| Architecture    | [design-and-architecture.md](design-and-architecture.md) | DDD, CQRS, hexagonal architecture, and bounded contexts         |
+| Development     | [developer-guide.md](developer-guide.md)                 | Code layout, implementation patterns, and Deptrac usage         |
+| API             | [api-endpoints.md](api-endpoints.md)                     | REST, GraphQL, OpenAPI, and request examples                    |
+| Database        | [database.md](database.md)                               | MongoDB collections, indexes, schema ownership, and migrations  |
+| Testing         | [testing.md](testing.md)                                 | Unit, integration, Behat, mutation, load, and API tests         |
+| Deployment      | [deployment.md](deployment.md)                           | Environment setup, release steps, and runtime dependencies      |
+| Operations      | [operational.md](operational.md)                         | Runtime checks, security posture, and support operations        |
+| Troubleshooting | [troubleshooting.md](troubleshooting.md)                 | Common local, CI, database, queue, and API issues               |
+| Configuration   | [advanced-configuration.md](advanced-configuration.md)   | Environment variables and load-test configuration               |
+| Security        | [security.md](security.md)                               | Secure development and dependency practices                     |
+| Performance     | [performance.md](performance.md)                         | Performance benchmarks and optimization notes                   |
+| Versioning      | [versioning.md](versioning.md)                           | Version policy and deprecation expectations                     |
+| Releases        | [release-notes.md](release-notes.md)                     | Release process and changelog usage                             |
+| Community       | [community-and-support.md](community-and-support.md)     | Support and issue reporting channels                            |
+| Glossary        | [glossary.md](glossary.md)                               | Shared domain vocabulary and naming conventions                 |
+| Usage           | [user-guide.md](user-guide.md)                           | API usage walkthroughs                                          |
+| Licensing       | [legal-and-licensing.md](legal-and-licensing.md)         | License and third-party package notes                           |
 
 ## Generated Documentation
 

--- a/docs/database.md
+++ b/docs/database.md
@@ -19,9 +19,9 @@ Doctrine ODM XML mappings are the source of truth for persisted fields, identifi
 When changing persistence behavior:
 
 1. Update the mapped domain entity and its XML mapping together.
-2. Update validators and serialization metadata when API-visible fields change.
-3. Update OpenAPI/GraphQL expectations when the API contract changes.
-4. Update this document if a collection, relation, index, or ownership rule changes.
+2. When API-visible fields change, update validators and serialization metadata.
+3. Adjust OpenAPI/GraphQL expectations to reflect API contract changes.
+4. Revise this document for changes to collections, relations, indexes, or ownership rules.
 5. Add or adjust tests that exercise repository and API behavior.
 
 ## Identifiers

--- a/docs/database.md
+++ b/docs/database.md
@@ -4,10 +4,10 @@ Core Service persists customer-domain data in MongoDB through Doctrine MongoDB O
 
 ## Document Ownership
 
-| Domain concept | Mapping file | Owning context | Purpose |
-| --- | --- | --- | --- |
-| Customer | `config/doctrine/Customer.mongodb.xml` | `Core/Customer` | Main customer aggregate and contact fields |
-| Customer type | `config/doctrine/CustomerType.mongodb.xml` | `Core/Customer` | Classification values referenced by customers |
+| Domain concept  | Mapping file                                 | Owning context  | Purpose                                         |
+| --------------- | -------------------------------------------- | --------------- | ----------------------------------------------- |
+| Customer        | `config/doctrine/Customer.mongodb.xml`       | `Core/Customer` | Main customer aggregate and contact fields      |
+| Customer type   | `config/doctrine/CustomerType.mongodb.xml`   | `Core/Customer` | Classification values referenced by customers   |
 | Customer status | `config/doctrine/CustomerStatus.mongodb.xml` | `Core/Customer` | Lifecycle status values referenced by customers |
 
 The `Shared` and `Internal/HealthCheck` contexts do not own MongoDB collections directly. Shared classes provide cross-cutting abstractions, and health checks verify connectivity.

--- a/docs/database.md
+++ b/docs/database.md
@@ -1,0 +1,59 @@
+# Database
+
+Core Service persists customer-domain data in MongoDB through Doctrine MongoDB ODM. Mapping files live in `config/doctrine/`, and repository implementations live under the owning bounded context in `src/Core/Customer/Infrastructure/Repository/`.
+
+## Document Ownership
+
+| Domain concept | Mapping file | Owning context | Purpose |
+| --- | --- | --- | --- |
+| Customer | `config/doctrine/Customer.mongodb.xml` | `Core/Customer` | Main customer aggregate and contact fields |
+| Customer type | `config/doctrine/CustomerType.mongodb.xml` | `Core/Customer` | Classification values referenced by customers |
+| Customer status | `config/doctrine/CustomerStatus.mongodb.xml` | `Core/Customer` | Lifecycle status values referenced by customers |
+
+The `Shared` and `Internal/HealthCheck` contexts do not own MongoDB collections directly. Shared classes provide cross-cutting abstractions, and health checks verify connectivity.
+
+## Schema Source of Truth
+
+Doctrine ODM XML mappings are the source of truth for persisted fields, identifiers, indexes, embedded references, and lifecycle timestamps. Do not duplicate persistence rules in controllers or API Platform resources.
+
+When changing persistence behavior:
+
+1. Update the mapped domain entity and its XML mapping together.
+2. Update validators and serialization metadata when API-visible fields change.
+3. Update OpenAPI/GraphQL expectations when the API contract changes.
+4. Update this document if a collection, relation, index, or ownership rule changes.
+5. Add or adjust tests that exercise repository and API behavior.
+
+## Identifiers
+
+The service uses ULID-based identifiers in the domain model. API resources expose identifiers through API Platform IRIs such as `/api/customers/{id}`.
+
+Keep identifier conversion at the application and infrastructure boundaries. Domain code should depend on typed value objects rather than raw request strings.
+
+## Indexing
+
+Indexes should be declared in Doctrine ODM mappings when query behavior requires stable performance. Existing query surfaces include customer collection reads, filtering, sorting, and lookup by related customer type or status.
+
+Before adding a new filter or sort option:
+
+- confirm the query is part of the API contract
+- add or reuse an index that supports the expected access pattern
+- add load or API tests if the query is user-facing and performance-sensitive
+
+## Local Schema Commands
+
+For local and test environments, schema setup is wrapped by Make targets:
+
+```bash
+make setup-test-db
+```
+
+The target starts required services, clears the test cache, drops the test schema, and recreates it with tolerance for already-existing collections.
+
+Do not use test schema reset commands against shared or production databases.
+
+## Data Safety
+
+Customer records can contain personal or business contact data. Treat database dumps, fixtures, logs, and test artifacts as sensitive unless they are explicitly synthetic.
+
+Operational data-handling expectations are documented in [security.md](security.md) and [operational.md](operational.md).

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -1,0 +1,85 @@
+# Deployment
+
+This guide covers the deployment concerns that are specific to Core Service. It assumes the target platform already provides container orchestration, TLS termination, secret management, and observability.
+
+## Runtime Components
+
+Core Service runs as a PHP/Symfony application with these required dependencies:
+
+- PHP application container
+- Caddy or another HTTP edge for local and deployed HTTP routing
+- MongoDB for customer, customer type, and customer status documents
+- Redis for cache storage
+- Amazon SQS compatible queue transport for asynchronous work
+- Structurizr workspace service for architecture diagrams when enabled
+
+The local Docker Compose stack is the reference environment for wiring these services together.
+
+## Configuration Inputs
+
+Deployment configuration is supplied through environment variables. Keep production values in the platform secret store rather than committed `.env` files.
+
+Required production values include:
+
+- `APP_ENV=prod`
+- `APP_SECRET`
+- `DB_URL`
+- `MESSENGER_TRANSPORT_DSN`
+- `AWS_SQS_REGION`
+- `AWS_SQS_KEY`
+- `AWS_SQS_SECRET`
+- `EMAIL_QUEUE_NAME`
+- `SERVER_NAME`
+
+See [advanced-configuration.md](advanced-configuration.md) for the complete environment-variable catalogue.
+
+## Build and Release Flow
+
+1. Build the application image from the repository Dockerfile.
+2. Install Composer dependencies from the committed `composer.lock`.
+3. Run CI quality gates before promotion:
+   - `make validate-configuration`
+   - `make docs-check`
+   - `make psalm`
+   - `make deptrac`
+   - `make phpunit`
+   - `make behat`
+4. Publish the immutable image to the registry used by the deployment platform.
+5. Roll out the image with the approved production environment variables.
+6. Run smoke checks against `/api/health`, `/api/docs`, and one read-only collection endpoint.
+
+## Database and Queue Preparation
+
+Core Service uses MongoDB ODM mappings under `config/doctrine/`. The deployment platform must provide the database before the app starts.
+
+For new environments:
+
+```bash
+make up
+make setup-test-db
+```
+
+Production schema creation should be handled by the deployment runbook for the target platform. Do not run destructive schema-drop commands against production databases.
+
+Queue configuration is handled by Symfony Messenger. Ensure the configured queue exists and the worker runtime has permission to consume and acknowledge messages.
+
+## Health and Smoke Checks
+
+Use the health endpoint for readiness checks:
+
+```bash
+curl -k https://localhost/api/health
+```
+
+A healthy response confirms that the application can execute its configured health subscribers. For deeper release validation, also confirm that API documentation loads and an authenticated API flow can create, read, update, and delete a test customer in a non-production environment.
+
+## Rollback
+
+Rollback should deploy the previously known-good image and preserve database data. Because MongoDB schema changes are owned by Doctrine ODM mappings, any future migration that changes document shape must include a dedicated rollback note in the same PR.
+
+## Related Documents
+
+- [database.md](database.md)
+- [operational.md](operational.md)
+- [security.md](security.md)
+- [testing.md](testing.md)

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -10,7 +10,7 @@ Core Service runs as a PHP/Symfony application with these required dependencies:
 - Caddy or another HTTP edge for local and deployed HTTP routing
 - MongoDB for customer, customer type, and customer status documents
 - Redis for cache storage
-- Amazon SQS compatible queue transport for asynchronous work
+- Amazon SQS-compatible queue transport for asynchronous work
 - Structurizr workspace service for architecture diagrams when enabled
 
 The local Docker Compose stack is the reference environment for wiring these services together.
@@ -24,7 +24,10 @@ Required production values include:
 - `APP_ENV=prod`
 - `APP_SECRET`
 - `DB_URL`
-- `MESSENGER_TRANSPORT_DSN`
+- `DOMAIN_EVENTS_TRANSPORT_DSN`
+- `FAILED_DOMAIN_EVENTS_TRANSPORT_DSN`
+- `CACHE_REFRESH_TRANSPORT_DSN`
+- `FAILED_CACHE_REFRESH_TRANSPORT_DSN`
 - `AWS_SQS_REGION`
 - `AWS_SQS_KEY`
 - `AWS_SQS_SECRET`
@@ -42,7 +45,7 @@ See [advanced-configuration.md](advanced-configuration.md) for the complete envi
    - `make docs-check`
    - `make psalm`
    - `make deptrac`
-   - `make phpunit`
+   - `make unit-tests`
    - `make behat`
 4. Publish the immutable image to the registry used by the deployment platform.
 5. Roll out the image with the approved production environment variables.

--- a/docs/main.md
+++ b/docs/main.md
@@ -58,4 +58,4 @@ When running the service locally, you can view interactive diagrams at [http://l
 
 Also, check [this link](https://structurizr.com/) to learn about the tool we used to create this diagram.
 
-Learn more about [Getting Started](getting-started.md).
+Continue with the [documentation index](README.md) or go directly to [Getting Started](getting-started.md).

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -75,7 +75,10 @@ Do not run schema-drop commands against production or shared databases.
 
 Symfony Messenger uses the configured transport DSN and queue name. Check:
 
-- `MESSENGER_TRANSPORT_DSN`
+- `DOMAIN_EVENTS_TRANSPORT_DSN`
+- `FAILED_DOMAIN_EVENTS_TRANSPORT_DSN`
+- `CACHE_REFRESH_TRANSPORT_DSN`
+- `FAILED_CACHE_REFRESH_TRANSPORT_DSN`
 - `EMAIL_QUEUE_NAME`
 - AWS SQS endpoint and credentials for the target environment
 - local AWS emulator health when running locally
@@ -99,7 +102,7 @@ Deptrac failures usually mean a new class crosses a forbidden layer or bounded-c
 Start with the smallest failing target:
 
 ```bash
-make phpunit
+make unit-tests
 make behat
 make bats
 ```

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,0 +1,136 @@
+# Troubleshooting
+
+Use this guide when local setup, CI checks, API access, database connectivity, or queue processing fails.
+
+## Local Stack Does Not Start
+
+Run:
+
+```bash
+docker compose ps
+docker compose logs --tail=100
+```
+
+Common causes:
+
+- a configured port is already in use
+- Docker Desktop or the Docker daemon is not running
+- a previous stack left stale containers behind
+- local environment overrides conflict with `.env.test`
+
+Stop and restart the stack:
+
+```bash
+make down
+make up
+```
+
+If a port conflict persists, override the relevant port when invoking Make, for example `HTTP_PORT=8088 make up`.
+
+## Composer Dependencies Are Missing
+
+If vendor binaries are missing or PHP commands fail with autoload errors, install dependencies inside the PHP container:
+
+```bash
+make install
+```
+
+Use the committed `composer.lock` for reproducible installs.
+
+## API Documentation Does Not Load
+
+Check that the HTTP stack is running:
+
+```bash
+make up
+curl -k https://localhost/api/docs
+```
+
+If the route returns an error, inspect application logs:
+
+```bash
+make logs
+```
+
+OpenAPI generation depends on API Platform resource configuration under `config/api_platform/resources/` and OpenAPI customization code under `src/Shared/Application/OpenApi/`.
+
+## Database Connection Fails
+
+Confirm the database container is running and the configured URL matches the active environment:
+
+```bash
+docker compose ps database
+docker compose logs --tail=100 database
+```
+
+For test environments, rebuild the schema:
+
+```bash
+make setup-test-db
+```
+
+Do not run schema-drop commands against production or shared databases.
+
+## Queue or Async Work Fails
+
+Symfony Messenger uses the configured transport DSN and queue name. Check:
+
+- `MESSENGER_TRANSPORT_DSN`
+- `EMAIL_QUEUE_NAME`
+- AWS SQS endpoint and credentials for the target environment
+- local AWS emulator health when running locally
+
+After configuration changes, restart the PHP container and queue worker process used by the environment.
+
+## Static Analysis Fails
+
+Run the focused command locally before rerunning the full CI job:
+
+```bash
+make psalm
+make deptrac
+make phpinsights
+```
+
+Deptrac failures usually mean a new class crosses a forbidden layer or bounded-context boundary. Update the design or the Deptrac configuration only when the new dependency is intentional and documented.
+
+## Tests Fail Locally
+
+Start with the smallest failing target:
+
+```bash
+make phpunit
+make behat
+make bats
+```
+
+If test services are stale, restart them and rebuild the test database:
+
+```bash
+make down
+make setup-test-db
+```
+
+For API-contract failures, compare the generated behavior with [api-endpoints.md](api-endpoints.md), `.github/openapi-spec/spec.yaml`, and `.github/graphql-spec/`.
+
+## Documentation Checks Fail
+
+Run:
+
+```bash
+make docs-check
+```
+
+The docs check verifies required documentation files, root README navigation, local Markdown links, and trailing whitespace. Fix the reported file and rerun the command before pushing.
+
+## Still Blocked
+
+Open a GitHub issue with:
+
+- the command that failed
+- the full error output
+- operating system and Docker version
+- branch and commit SHA
+- whether the failure happens locally, in CI, or both
+
+See [community-and-support.md](community-and-support.md) for support channels.

--- a/phpdoc.dist.xml
+++ b/phpdoc.dist.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<phpdocumentor
+    configVersion="3"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="https://docs.phpdoc.org/latest/phpdoc.xsd"
+>
+    <title>VilnaCRM Core Service API Reference</title>
+    <paths>
+        <output>build/docs/phpdoc</output>
+        <cache>build/docs/phpdoc-cache</cache>
+    </paths>
+    <version number="main">
+        <api format="php">
+            <source dsn=".">
+                <path>src</path>
+            </source>
+            <extensions>
+                <extension>php</extension>
+            </extensions>
+            <ignore hidden="true" symlinks="true">
+                <path>build/**/*</path>
+                <path>var/**/*</path>
+                <path>vendor/**/*</path>
+            </ignore>
+        </api>
+    </version>
+</phpdocumentor>

--- a/scripts/check-docs.sh
+++ b/scripts/check-docs.sh
@@ -48,7 +48,7 @@ for doc in "${required_docs[@]}"; do
   fi
 done
 
-if ! grep -Eq '\]\(docs/README\.md\)' "${ROOT_DIR}/README.md"; then
+if ! grep -Eq '\]\((\./)?docs/README\.md\)' "${ROOT_DIR}/README.md"; then
   fail "root README.md must link to docs/README.md"
 fi
 
@@ -56,11 +56,12 @@ if ! grep -Eq '^docs:.*## ' "${ROOT_DIR}/Makefile"; then
   fail "Makefile must expose a documented docs target"
 fi
 
-if grep -RIn '[[:blank:]]$' "${DOCS_DIR}" "${ROOT_DIR}/README.md" "${ROOT_DIR}/Makefile" >/tmp/core-service-docs-trailing-whitespace.$$; then
-  cat /tmp/core-service-docs-trailing-whitespace.$$ >&2
+tmp_ws_file="$(mktemp)"
+trap 'rm -f "${tmp_ws_file}"' EXIT
+if grep -RIn '[[:blank:]]$' "${DOCS_DIR}" "${ROOT_DIR}/README.md" "${ROOT_DIR}/Makefile" >"${tmp_ws_file}"; then
+  cat "${tmp_ws_file}" >&2
   fail "documentation files must not contain trailing whitespace"
 fi
-rm -f /tmp/core-service-docs-trailing-whitespace.$$
 
 link_sources=(
   "${ROOT_DIR}/README.md"

--- a/scripts/check-docs.sh
+++ b/scripts/check-docs.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+DOCS_DIR="${ROOT_DIR}/docs"
+
+required_docs=(
+  "README.md"
+  "main.md"
+  "getting-started.md"
+  "design-and-architecture.md"
+  "developer-guide.md"
+  "api-endpoints.md"
+  "testing.md"
+  "deployment.md"
+  "database.md"
+  "troubleshooting.md"
+  "security.md"
+  "operational.md"
+  "onboarding.md"
+  "advanced-configuration.md"
+  "performance.md"
+  "release-notes.md"
+  "versioning.md"
+  "community-and-support.md"
+  "legal-and-licensing.md"
+  "glossary.md"
+  "user-guide.md"
+)
+
+failures=0
+
+fail() {
+  printf 'docs-check: %s\n' "$1" >&2
+  failures=$((failures + 1))
+}
+
+for doc in "${required_docs[@]}"; do
+  path="${DOCS_DIR}/${doc}"
+
+  if [[ ! -s "${path}" ]]; then
+    fail "required document is missing or empty: docs/${doc}"
+    continue
+  fi
+
+  if ! head -n 1 "${path}" | grep -Eq '^# '; then
+    fail "document must start with an H1 heading: docs/${doc}"
+  fi
+done
+
+if ! grep -Eq '\]\(docs/README\.md\)' "${ROOT_DIR}/README.md"; then
+  fail "root README.md must link to docs/README.md"
+fi
+
+if ! grep -Eq '^docs:.*## ' "${ROOT_DIR}/Makefile"; then
+  fail "Makefile must expose a documented docs target"
+fi
+
+if grep -RIn '[[:blank:]]$' "${DOCS_DIR}" "${ROOT_DIR}/README.md" "${ROOT_DIR}/Makefile" >/tmp/core-service-docs-trailing-whitespace.$$; then
+  cat /tmp/core-service-docs-trailing-whitespace.$$ >&2
+  fail "documentation files must not contain trailing whitespace"
+fi
+rm -f /tmp/core-service-docs-trailing-whitespace.$$
+
+link_sources=(
+  "${ROOT_DIR}/README.md"
+  "${DOCS_DIR}"/*.md
+)
+
+while IFS=$'\t' read -r file target; do
+  [[ -n "${target}" ]] || continue
+
+  case "${target}" in
+    http://*|https://*|mailto:*|tel:*|'#'*)
+      continue
+      ;;
+  esac
+
+  target="${target%%#*}"
+  target="${target%%\?*}"
+  [[ -n "${target}" ]] || continue
+
+  if [[ "${target}" = /* ]]; then
+    resolved="$(realpath -m "${ROOT_DIR}${target}")"
+  else
+    resolved="$(realpath -m "$(dirname "${file}")/${target}")"
+  fi
+
+  case "${resolved}" in
+    "${ROOT_DIR}"/*) ;;
+    *)
+      fail "local link points outside repository: ${file} -> ${target}"
+      continue
+      ;;
+  esac
+
+  if [[ ! -e "${resolved}" ]]; then
+    fail "broken local Markdown link: ${file} -> ${target}"
+  fi
+done < <(
+  perl -0ne 'while (/\[[^\]]+\]\(([^)\s]+)\)/g) { print "$ARGV\t$1\n" }' "${link_sources[@]}"
+)
+
+if (( failures > 0 )); then
+  exit 1
+fi
+
+printf 'docs-check: validated %d required documents and local Markdown links\n' "${#required_docs[@]}"


### PR DESCRIPTION
## Description

Completes the comprehensive documentation workflow on top of the existing docs bundle already in main:

- Adds `docs/README.md` as the maintained documentation entry point.
- Adds missing deployment, database, and troubleshooting documentation.
- Updates the root README documentation section away from the old wiki flow.
- Adds `make docs-check` for required docs, H1 headings, local Markdown links, and trailing whitespace.
- Adds `make docs` with PHPDocumentor generation into ignored `build/docs/phpdoc`.
- Adds a pull-request documentation workflow that runs `make docs-check`.

## Related Issue

Closes #55

## Motivation and Context

Issue #55 asks for comprehensive project documentation, docs generation, README discoverability, and documentation validation. Main already contains the large documentation set from PR #89; this PR closes the remaining discoverability and workflow gaps needed to make that documentation maintainable.

## How Has This Been Tested?

- `make bmalph-init BMALPH_PLATFORM=codex BMALPH_DRY_RUN=true`
- `bmalph upgrade --force` with generated metadata drift restored
- `bmalph doctor` - 19 passed
- `make docs-check`
- `make docs`
- `bash -n scripts/check-docs.sh`
- `git diff --check HEAD`
- `make validate-configuration` - passed with the expected worktree `.git` warning

Runtime PHP tests were not run because this PR changes documentation, documentation tooling, and a docs-only CI workflow, not application behavior.

## Screenshots (if appropriate):

N/A

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

Documentation and documentation tooling only.

## Checklist:

- [x] My code follows the code style of this project.
- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING.md**](https://github.com/VilnaCRM-Org/core-service/blob/main/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] You have only one commit (if not, squash them into one commit).
- [ ] Structurizr documentation has been updated to reflect any architectural changes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Completes a maintainable docs workflow with a new docs index, stricter PR docs checks, and Dockerized PHP API reference generation. Updates README docs guidance and bumps `webonyx/graphql-php`; no runtime changes.

- **New Features**
  - Added `docs/README.md` as the docs index; added `docs/deployment.md`, `docs/database.md`, `docs/troubleshooting.md`; updated `README.md` and `docs/main.md` to point to the index and include docs commands.
  - Introduced `make docs-check` via `scripts/check-docs.sh` (validates required docs, H1s, local Markdown links, trailing whitespace; ensures root `README.md` links to the docs index and `Makefile` exposes a docs target) and a PR workflow `.github/workflows/documentation.yml` that runs it (`actions/checkout@v4`).
  - Added `make docs` to run checks and generate PHP API reference with PHPDocumentor Docker image `phpdoc/phpdoc:3.8.0` into `build/docs/phpdoc`; committed `phpdoc.dist.xml` and ignored `/build/`.

- **Dependencies**
  - Bumped `webonyx/graphql-php` to `v15.32.3` to address a vulnerability.

<sup>Written for commit fc123f864e3a124826331e36badbaeba7cb9c81f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

