### PR TITLE
fix(security): disable GraphQL introspection and GraphiQL in production

### DIFF
--- a/config/packages/api_platform.yaml
+++ b/config/packages/api_platform.yaml
@@ -57,7 +57,12 @@ api_platform:
 when@prod:
   api_platform:
     graphql:
+      # Close every interactive IDE surface in production, not just GraphiQL:
+      # no default IDE, and explicitly disable the (deprecated) Playground node.
+      default_ide: false
       graphiql:
+        enabled: false
+      graphql_playground:
         enabled: false
       introspection:
         enabled: false

--- a/config/packages/api_platform.yaml
+++ b/config/packages/api_platform.yaml
@@ -36,6 +36,10 @@ api_platform:
     # Default to ID for mutations
     default_ide: graphiql
     nesting_separator: _
+    # Pin query-cost limits explicitly (these are the API Platform defaults)
+    # so they remain visible and stable as a defense-in-depth DoS guard.
+    max_query_depth: 20
+    max_query_complexity: 500
 
   # Tell API Platform where your domain classes live
   resource_class_directories:
@@ -46,3 +50,14 @@ api_platform:
   mapping:
     paths:
       - '%kernel.project_dir%/config/api_platform/resources'
+
+# Production hardening: never expose the interactive GraphQL IDE or schema
+# introspection in production. The schema, queries and mutations must not be
+# enumerable by anonymous clients. Dev/test keep GraphiQL + introspection on.
+when@prod:
+  api_platform:
+    graphql:
+      graphiql:
+        enabled: false
+      introspection:
+        enabled: false


### PR DESCRIPTION
## What
Disables the GraphQL **GraphiQL IDE** and **schema introspection** in the `prod` environment via a `when@prod` override, and pins the query-depth/complexity limits explicitly.

## Why
GraphiQL and introspection were on in every environment (`config/packages/api_platform.yaml`), so an anonymous client in production could enumerate the entire schema (all types, queries, mutations) and use the interactive IDE — CWE-200 / CWE-489.

Note: API Platform 4 already enforces `max_query_depth=20` / `max_query_complexity=500` by default, so query-cost DoS was already mitigated; this PR makes those limits explicit for visibility/stability and closes the schema/IDE exposure.

## Change
```yaml
# config/packages/api_platform.yaml
when@prod:
  api_platform:
    graphql:
      graphiql:
        enabled: false
      introspection:
        enabled: false
```
Dev/test keep GraphiQL + introspection enabled, so the generated GraphQL schema (used by the `graphql-diff` check) is unchanged.

## Validation
- YAML parses; config keys verified against API Platform 4 `Configuration.php` (`graphiql.enabled`, `introspection.enabled`, `max_query_depth`, `max_query_complexity`).
- Config-only; no application code or generated-spec change.

Closes #218

🤖 Generated as part of an autonomous penetration-test remediation sweep.

---
_Generated by [Claude Code](https://claude.ai/code/session_01D7yJf4tLNuFTSPDA3RBcTp)_

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Disable all GraphQL IDEs and schema introspection in production to block anonymous schema enumeration. Add a `when@prod` override to set `default_ide: false` and disable `graphiql` + `graphql_playground`, and pin `max_query_depth: 20` / `max_query_complexity: 500` in `api_platform`; dev/test remain unchanged.

<sup>Written for commit 20e010a312cedbece53281f9671909616507214b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/VilnaCRM-Org/core-service/pull/225?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

