### PR TITLE
fix(security): add HTTP security headers at the Caddy edge

### DIFF
--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -11,6 +11,8 @@ services:
       FRANKENPHP_WORKER_CONFIG: ${FRANKENPHP_WORKER_CONFIG-watch}
       XDEBUG_MODE: '${XDEBUG_MODE:-off}'
       SERVER_NAME: ${SERVER_NAME:-localhost}, php:80
+      # Relax the strict prod CSP locally so the GraphiQL IDE can load its assets.
+      CADDY_CSP: "${CADDY_CSP:-default-src 'self' 'unsafe-inline' 'unsafe-eval' data: blob:}"
     volumes:
       - ./:/srv/app
       - ./frankenphp/Caddyfile:/etc/frankenphp/Caddyfile:ro

--- a/frankenphp/Caddyfile
+++ b/frankenphp/Caddyfile
@@ -35,7 +35,19 @@
 
 	{$CADDY_SERVER_EXTRA_DIRECTIVES}
 
-	header ?Permissions-Policy "browsing-topics=()"
+	header {
+		?Permissions-Policy "browsing-topics=()"
+		Strict-Transport-Security "max-age=31536000; includeSubDomains; preload"
+		X-Content-Type-Options "nosniff"
+		X-Frame-Options "DENY"
+		Referrer-Policy "no-referrer"
+		Cross-Origin-Opener-Policy "same-origin"
+		# Strict by default (JSON/GraphQL API). The dev compose override relaxes
+		# CADDY_CSP so the GraphiQL IDE keeps working locally.
+		Content-Security-Policy "{$CADDY_CSP:default-src 'none'; frame-ancestors 'none'; base-uri 'none'}"
+		-X-Powered-By
+		-Server
+	}
 
 	@phpRoute {
 		not path /.well-known/mercure*


### PR DESCRIPTION
## What
Adds hardened HTTP response headers in `frankenphp/Caddyfile`. Previously only `Permissions-Policy` was set.

| Header | Value |
|--------|-------|
| `Strict-Transport-Security` | `max-age=31536000; includeSubDomains; preload` |
| `X-Content-Type-Options` | `nosniff` |
| `X-Frame-Options` | `DENY` |
| `Referrer-Policy` | `no-referrer` |
| `Cross-Origin-Opener-Policy` | `same-origin` |
| `Content-Security-Policy` | `{$CADDY_CSP:default-src 'none'; frame-ancestors 'none'; base-uri 'none'}` |
| `Server`, `X-Powered-By` | removed |

## Why
CWE-693 / CWE-1021: responses shipped without transport-security, anti-sniffing, or anti-framing headers, exposing clients to downgrade, MIME-sniffing, and clickjacking.

## GraphiQL compatibility
The CSP defaults to a strict policy for production (the API serves JSON/GraphQL). Because the same `Caddyfile` is mounted in dev, the strict `default-src 'none'` would break the GraphiQL IDE locally — so CSP is **env-driven via `CADDY_CSP`** and `docker-compose.override.yml` (dev) sets a relaxed value that lets GraphiQL load its assets. Prod uses the strict default.

## Validation
- `docker compose -f docker-compose.yml -f docker-compose.override.yml config` merges cleanly; `CADDY_CSP` renders as expected.
- Config-only; no application code change.

Closes #219

🤖 Generated as part of an autonomous penetration-test remediation sweep.

---
_Generated by [Claude Code](https://claude.ai/code/session_01D7yJf4tLNuFTSPDA3RBcTp)_

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add hardened HTTP security headers at the Caddy edge and a strict, env-driven CSP. Keeps GraphiQL working in dev while locking down production.

- **New Features**
  - Add `Strict-Transport-Security` (31536000; includeSubDomains; preload), `X-Content-Type-Options: nosniff`, `X-Frame-Options: DENY`, `Referrer-Policy: no-referrer`, and `Cross-Origin-Opener-Policy: same-origin`.
  - Default CSP is strict: `default-src 'none'; frame-ancestors 'none'; base-uri 'none'`.
  - Make CSP configurable via `CADDY_CSP`; `docker-compose.override.yml` relaxes it for GraphiQL in dev.
  - Remove `Server` and `X-Powered-By` response headers.

<sup>Written for commit 23a606afb108accdf48df42bfee6e7dd3de29418. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/VilnaCRM-Org/core-service/pull/226?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

