### PR TITLE
fix(security): replace unsafe reflection in UlidFilterProcessor with an allow-list

### DIFF
--- a/src/Shared/Infrastructure/Filter/UlidFilterProcessor.php
+++ b/src/Shared/Infrastructure/Filter/UlidFilterProcessor.php
@@ -70,9 +70,19 @@ final class UlidFilterProcessor
         string $field,
         Builder $builder
     ): void {
-        $class = __NAMESPACE__ . '\\' . ucfirst($operator);
-        /** @var OperatorStrategyInterface $operatorStrategy */
-        $operatorStrategy = new $class();
-        $operatorStrategy->apply($builder, $field, $filterValue);
+        $strategies = [
+            'between' => new Between(),
+            'gt' => new Gt(),
+            'gte' => new Gte(),
+            'lt' => new Lt(),
+            'lte' => new Lte(),
+        ];
+
+        $strategy = $strategies[$operator] ?? null;
+        if ($strategy === null) {
+            return;
+        }
+
+        $strategy->apply($builder, $field, $filterValue);
     }
 }

--- a/tests/Unit/Shared/Infrastructure/Filter/UlidFilterProcessorTest.php
+++ b/tests/Unit/Shared/Infrastructure/Filter/UlidFilterProcessorTest.php
@@ -89,6 +89,14 @@ final class UlidFilterProcessorTest extends UnitTestCase
         $this->processor->process('ulid', 'gte', $ulid, $this->builder);
     }
 
+    public function testProcessSkipsUnknownOperator(): void
+    {
+        $ulid = (string) $this->faker->ulid();
+        $this->builder->expects($this->never())->method('match');
+
+        $this->processor->process('ulid', 'evil', $ulid, $this->builder);
+    }
+
     public function testProcessSkipsInvalidUlid(): void
     {
         $this->builder->expects($this->never())->method('match');


### PR DESCRIPTION
## What
Replaces the request-driven dynamic class instantiation in `UlidFilterProcessor::applyOperator()` with an explicit operator→strategy allow-list, and treats unknown operators as a safe no-op.

### Before
```php
$class = __NAMESPACE__ . '\\' . ucfirst($operator); // $operator from request
$operatorStrategy = new $class();
$operatorStrategy->apply($builder, $field, $filterValue);
```
### After
```php
$strategies = [
    'between' => new Between(), 'gt' => new Gt(), 'gte' => new Gte(),
    'lt' => new Lt(), 'lte' => new Lte(),
];
$strategy = $strategies[$operator] ?? null;
if ($strategy === null) { return; }
$strategy->apply($builder, $field, $filterValue);
```

## Why
CWE-470 (Unsafe Reflection): the operator came from attacker-controlled filter array keys. Exploitability was limited (namespace-pinned, no-arg constructor, post-`Ulid::isValid()`), worst case an unintended instantiation or a 500. This removes the reflection entirely. Operator keys (`lt/lte/gt/gte/between`) confirmed from `UlidRangeFilter::getDescription()`.

## Tests
Added `UlidFilterProcessorTest::testProcessSkipsUnknownOperator` asserting an unknown operator never touches the query builder and throws nothing (kills the early-return-guard mutation). Existing per-operator tests still pass (35 tests / 62 assertions locally).

> Coverage/Infection/full-psalm were not runnable in the sandbox (no pcov driver / parallel-pool limitation) — relying on CI for those gates.

Closes #222

🤖 Generated as part of an autonomous penetration-test remediation sweep.

---
_Generated by [Claude Code](https://claude.ai/code/session_01D7yJf4tLNuFTSPDA3RBcTp)_

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replace request-driven class instantiation in UlidFilterProcessor with an explicit operator-to-strategy allow-list. This removes the unsafe reflection path (CWE-470) and makes unknown operators a safe no-op.

- **Bug Fixes**
  - Map supported operators to strategies: between, gt, gte, lt, lte; apply only when found.
  - Add test ensuring unknown operators do nothing and never touch the query builder.

<sup>Written for commit c047f7fd5ab55d7a51ebb8523da9aaec353f4eab. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/VilnaCRM-Org/core-service/pull/227?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

