### PR TITLE
fix(security): use a CSPRNG for domain event IDs

### DIFF
--- a/src/Core/Customer/Domain/Event/CustomerCreatedEvent.php
+++ b/src/Core/Customer/Domain/Event/CustomerCreatedEvent.php
@@ -54,6 +54,6 @@ final class CustomerCreatedEvent extends DomainEvent
 
     private function generateEventId(): string
     {
-        return uniqid('customer_created_', true);
+        return 'customer_created_' . bin2hex(random_bytes(16));
     }
 }

--- a/src/Core/Customer/Domain/Event/CustomerCreatedEvent.php
+++ b/src/Core/Customer/Domain/Event/CustomerCreatedEvent.php
@@ -21,7 +21,7 @@ final class CustomerCreatedEvent extends DomainEvent
         ?string $occurredOn = null
     ) {
         parent::__construct(
-            $eventId ?? $this->generateEventId(),
+            $eventId ?? $this->generateEventId('customer_created_'),
             $occurredOn
         );
     }
@@ -50,10 +50,5 @@ final class CustomerCreatedEvent extends DomainEvent
     public function customerEmail(): string
     {
         return $this->customerEmail;
-    }
-
-    private function generateEventId(): string
-    {
-        return 'customer_created_' . bin2hex(random_bytes(16));
     }
 }

--- a/src/Core/Customer/Domain/Event/CustomerDeletedEvent.php
+++ b/src/Core/Customer/Domain/Event/CustomerDeletedEvent.php
@@ -54,6 +54,6 @@ final class CustomerDeletedEvent extends DomainEvent
 
     private function generateEventId(): string
     {
-        return uniqid('customer_deleted_', true);
+        return 'customer_deleted_' . bin2hex(random_bytes(16));
     }
 }

--- a/src/Core/Customer/Domain/Event/CustomerDeletedEvent.php
+++ b/src/Core/Customer/Domain/Event/CustomerDeletedEvent.php
@@ -21,7 +21,7 @@ final class CustomerDeletedEvent extends DomainEvent
         ?string $occurredOn = null
     ) {
         parent::__construct(
-            $eventId ?? $this->generateEventId(),
+            $eventId ?? $this->generateEventId('customer_deleted_'),
             $occurredOn
         );
     }
@@ -50,10 +50,5 @@ final class CustomerDeletedEvent extends DomainEvent
     public function customerEmail(): string
     {
         return $this->customerEmail;
-    }
-
-    private function generateEventId(): string
-    {
-        return 'customer_deleted_' . bin2hex(random_bytes(16));
     }
 }

--- a/src/Core/Customer/Domain/Event/CustomerStatusCreatedEvent.php
+++ b/src/Core/Customer/Domain/Event/CustomerStatusCreatedEvent.php
@@ -18,7 +18,7 @@ final class CustomerStatusCreatedEvent extends DomainEvent
         ?string $occurredOn = null
     ) {
         parent::__construct(
-            $eventId ?? $this->generateEventId(),
+            $eventId ?? $this->generateEventId('customer_status_created_'),
             $occurredOn
         );
     }
@@ -47,10 +47,5 @@ final class CustomerStatusCreatedEvent extends DomainEvent
     public function customerStatusValue(): string
     {
         return $this->customerStatusValue;
-    }
-
-    private function generateEventId(): string
-    {
-        return 'customer_status_created_' . bin2hex(random_bytes(16));
     }
 }

--- a/src/Core/Customer/Domain/Event/CustomerStatusCreatedEvent.php
+++ b/src/Core/Customer/Domain/Event/CustomerStatusCreatedEvent.php
@@ -51,6 +51,6 @@ final class CustomerStatusCreatedEvent extends DomainEvent
 
     private function generateEventId(): string
     {
-        return uniqid('customer_status_created_', true);
+        return 'customer_status_created_' . bin2hex(random_bytes(16));
     }
 }

--- a/src/Core/Customer/Domain/Event/CustomerStatusUpdatedEvent.php
+++ b/src/Core/Customer/Domain/Event/CustomerStatusUpdatedEvent.php
@@ -64,6 +64,6 @@ final class CustomerStatusUpdatedEvent extends DomainEvent
 
     private function generateEventId(): string
     {
-        return uniqid('customer_status_updated_', true);
+        return 'customer_status_updated_' . bin2hex(random_bytes(16));
     }
 }

--- a/src/Core/Customer/Domain/Event/CustomerStatusUpdatedEvent.php
+++ b/src/Core/Customer/Domain/Event/CustomerStatusUpdatedEvent.php
@@ -19,7 +19,7 @@ final class CustomerStatusUpdatedEvent extends DomainEvent
         ?string $occurredOn = null
     ) {
         parent::__construct(
-            $eventId ?? $this->generateEventId(),
+            $eventId ?? $this->generateEventId('customer_status_updated_'),
             $occurredOn
         );
     }
@@ -60,10 +60,5 @@ final class CustomerStatusUpdatedEvent extends DomainEvent
     {
         return $this->previousValue !== null
             && $this->previousValue !== $this->currentValue;
-    }
-
-    private function generateEventId(): string
-    {
-        return 'customer_status_updated_' . bin2hex(random_bytes(16));
     }
 }

--- a/src/Core/Customer/Domain/Event/CustomerTypeCreatedEvent.php
+++ b/src/Core/Customer/Domain/Event/CustomerTypeCreatedEvent.php
@@ -51,6 +51,6 @@ final class CustomerTypeCreatedEvent extends DomainEvent
 
     private function generateEventId(): string
     {
-        return uniqid('customer_type_created_', true);
+        return 'customer_type_created_' . bin2hex(random_bytes(16));
     }
 }

--- a/src/Core/Customer/Domain/Event/CustomerTypeCreatedEvent.php
+++ b/src/Core/Customer/Domain/Event/CustomerTypeCreatedEvent.php
@@ -18,7 +18,7 @@ final class CustomerTypeCreatedEvent extends DomainEvent
         ?string $occurredOn = null
     ) {
         parent::__construct(
-            $eventId ?? $this->generateEventId(),
+            $eventId ?? $this->generateEventId('customer_type_created_'),
             $occurredOn
         );
     }
@@ -47,10 +47,5 @@ final class CustomerTypeCreatedEvent extends DomainEvent
     public function customerTypeValue(): string
     {
         return $this->customerTypeValue;
-    }
-
-    private function generateEventId(): string
-    {
-        return 'customer_type_created_' . bin2hex(random_bytes(16));
     }
 }

--- a/src/Core/Customer/Domain/Event/CustomerTypeUpdatedEvent.php
+++ b/src/Core/Customer/Domain/Event/CustomerTypeUpdatedEvent.php
@@ -64,6 +64,6 @@ final class CustomerTypeUpdatedEvent extends DomainEvent
 
     private function generateEventId(): string
     {
-        return uniqid('customer_type_updated_', true);
+        return 'customer_type_updated_' . bin2hex(random_bytes(16));
     }
 }

--- a/src/Core/Customer/Domain/Event/CustomerTypeUpdatedEvent.php
+++ b/src/Core/Customer/Domain/Event/CustomerTypeUpdatedEvent.php
@@ -19,7 +19,7 @@ final class CustomerTypeUpdatedEvent extends DomainEvent
         ?string $occurredOn = null
     ) {
         parent::__construct(
-            $eventId ?? $this->generateEventId(),
+            $eventId ?? $this->generateEventId('customer_type_updated_'),
             $occurredOn
         );
     }
@@ -60,10 +60,5 @@ final class CustomerTypeUpdatedEvent extends DomainEvent
     {
         return $this->previousValue !== null
             && $this->previousValue !== $this->currentValue;
-    }
-
-    private function generateEventId(): string
-    {
-        return 'customer_type_updated_' . bin2hex(random_bytes(16));
     }
 }

--- a/src/Core/Customer/Domain/Event/CustomerUpdatedEvent.php
+++ b/src/Core/Customer/Domain/Event/CustomerUpdatedEvent.php
@@ -23,7 +23,7 @@ final class CustomerUpdatedEvent extends DomainEvent
         ?string $occurredOn = null
     ) {
         parent::__construct(
-            $eventId ?? $this->generateEventId(),
+            $eventId ?? $this->generateEventId('customer_updated_'),
             $occurredOn
         );
     }
@@ -70,10 +70,5 @@ final class CustomerUpdatedEvent extends DomainEvent
     {
         return $this->previousEmail !== null
             && $this->previousEmail !== $this->currentEmail;
-    }
-
-    private function generateEventId(): string
-    {
-        return 'customer_updated_' . bin2hex(random_bytes(16));
     }
 }

--- a/src/Core/Customer/Domain/Event/CustomerUpdatedEvent.php
+++ b/src/Core/Customer/Domain/Event/CustomerUpdatedEvent.php
@@ -74,6 +74,6 @@ final class CustomerUpdatedEvent extends DomainEvent
 
     private function generateEventId(): string
     {
-        return uniqid('customer_updated_', true);
+        return 'customer_updated_' . bin2hex(random_bytes(16));
     }
 }

--- a/src/Shared/Domain/Bus/Event/DomainEvent.php
+++ b/src/Shared/Domain/Bus/Event/DomainEvent.php
@@ -36,6 +36,11 @@ abstract class DomainEvent
         return $this->occurredOn;
     }
 
+    protected function generateEventId(string $prefix): string
+    {
+        return $prefix . bin2hex(random_bytes(16));
+    }
+
     private function dateToString(DateTimeInterface $date): string
     {
         return $date->format(DateTimeInterface::ATOM);

--- a/tests/Unit/Customer/Domain/Event/CustomerCreatedEventTest.php
+++ b/tests/Unit/Customer/Domain/Event/CustomerCreatedEventTest.php
@@ -75,4 +75,31 @@ final class CustomerCreatedEventTest extends UnitTestCase
         self::assertSame($eventId, $event->eventId());
         self::assertSame($occurredOn, $event->occurredOn());
     }
+
+    public function testGeneratedEventIdUsesPrefixedRandomHex(): void
+    {
+        $eventId = (new CustomerCreatedEvent(
+            (string) $this->faker->ulid(),
+            $this->faker->email()
+        ))->eventId();
+
+        self::assertStringStartsWith('customer_created_', $eventId);
+        self::assertMatchesRegularExpression(
+            '/^customer_created_[0-9a-f]{32}$/',
+            $eventId
+        );
+    }
+
+    public function testGeneratedEventIdsAreUnique(): void
+    {
+        $ids = [];
+        for ($i = 0; $i < 1000; ++$i) {
+            $ids[] = (new CustomerCreatedEvent(
+                (string) $this->faker->ulid(),
+                $this->faker->email()
+            ))->eventId();
+        }
+
+        self::assertCount(1000, array_unique($ids));
+    }
 }

--- a/tests/Unit/Customer/Domain/Event/CustomerDeletedEventTest.php
+++ b/tests/Unit/Customer/Domain/Event/CustomerDeletedEventTest.php
@@ -75,4 +75,31 @@ final class CustomerDeletedEventTest extends UnitTestCase
         self::assertSame($eventId, $event->eventId());
         self::assertSame($occurredOn, $event->occurredOn());
     }
+
+    public function testGeneratedEventIdUsesPrefixedRandomHex(): void
+    {
+        $eventId = (new CustomerDeletedEvent(
+            (string) $this->faker->ulid(),
+            $this->faker->email()
+        ))->eventId();
+
+        self::assertStringStartsWith('customer_deleted_', $eventId);
+        self::assertMatchesRegularExpression(
+            '/^customer_deleted_[0-9a-f]{32}$/',
+            $eventId
+        );
+    }
+
+    public function testGeneratedEventIdsAreUnique(): void
+    {
+        $ids = [];
+        for ($i = 0; $i < 1000; ++$i) {
+            $ids[] = (new CustomerDeletedEvent(
+                (string) $this->faker->ulid(),
+                $this->faker->email()
+            ))->eventId();
+        }
+
+        self::assertCount(1000, array_unique($ids));
+    }
 }

--- a/tests/Unit/Customer/Domain/Event/CustomerReferenceEventTest.php
+++ b/tests/Unit/Customer/Domain/Event/CustomerReferenceEventTest.php
@@ -123,8 +123,60 @@ final class CustomerReferenceEventTest extends UnitTestCase
         }
     }
 
+    public function testCreatedReferenceEventsGeneratePrefixedRandomHexIds(): void
+    {
+        foreach ($this->createdEventCases() as [$eventClass, , , , , , $prefix]) {
+            $eventId = (new $eventClass(
+                (string) $this->faker->ulid(),
+                $this->faker->word()
+            ))->eventId();
+
+            self::assertStringStartsWith($prefix, $eventId);
+            self::assertMatchesRegularExpression(
+                '/^' . preg_quote($prefix, '/') . '[0-9a-f]{32}$/',
+                $eventId
+            );
+
+            $ids = [];
+            for ($i = 0; $i < 1000; ++$i) {
+                $ids[] = (new $eventClass(
+                    (string) $this->faker->ulid(),
+                    $this->faker->word()
+                ))->eventId();
+            }
+
+            self::assertCount(1000, array_unique($ids));
+        }
+    }
+
+    public function testUpdatedReferenceEventsGeneratePrefixedRandomHexIds(): void
+    {
+        foreach ($this->updatedEventCases() as [$eventClass, , , , $prefix]) {
+            $eventId = (new $eventClass(
+                (string) $this->faker->ulid(),
+                'active'
+            ))->eventId();
+
+            self::assertStringStartsWith($prefix, $eventId);
+            self::assertMatchesRegularExpression(
+                '/^' . preg_quote($prefix, '/') . '[0-9a-f]{32}$/',
+                $eventId
+            );
+
+            $ids = [];
+            for ($i = 0; $i < 1000; ++$i) {
+                $ids[] = (new $eventClass(
+                    (string) $this->faker->ulid(),
+                    'active'
+                ))->eventId();
+            }
+
+            self::assertCount(1000, array_unique($ids));
+        }
+    }
+
     /**
-     * @return iterable<string, array{0: class-string, 1: string, 2: string, 3: string, 4: string, 5: string}>
+     * @return iterable<string, array{0: class-string, 1: string, 2: string, 3: string, 4: string, 5: string, 6: string}>
      */
     private function createdEventCases(): iterable
     {
@@ -135,6 +187,7 @@ final class CustomerReferenceEventTest extends UnitTestCase
             'customer_status_value',
             'customerStatusId',
             'customerStatusValue',
+            'customer_status_created_',
         ];
 
         yield 'type created' => [
@@ -144,11 +197,12 @@ final class CustomerReferenceEventTest extends UnitTestCase
             'customer_type_value',
             'customerTypeId',
             'customerTypeValue',
+            'customer_type_created_',
         ];
     }
 
     /**
-     * @return iterable<string, array{0: class-string, 1: string, 2: string, 3: string}>
+     * @return iterable<string, array{0: class-string, 1: string, 2: string, 3: string, 4: string}>
      */
     private function updatedEventCases(): iterable
     {
@@ -157,6 +211,7 @@ final class CustomerReferenceEventTest extends UnitTestCase
             'customer_status.updated',
             'customer_status_id',
             'customerStatusId',
+            'customer_status_updated_',
         ];
 
         yield 'type updated' => [
@@ -164,6 +219,7 @@ final class CustomerReferenceEventTest extends UnitTestCase
             'customer_type.updated',
             'customer_type_id',
             'customerTypeId',
+            'customer_type_updated_',
         ];
     }
 }

--- a/tests/Unit/Customer/Domain/Event/CustomerUpdatedEventTest.php
+++ b/tests/Unit/Customer/Domain/Event/CustomerUpdatedEventTest.php
@@ -174,4 +174,31 @@ final class CustomerUpdatedEventTest extends UnitTestCase
 
         self::assertFalse($event->emailChanged());
     }
+
+    public function testGeneratedEventIdUsesPrefixedRandomHex(): void
+    {
+        $eventId = (new CustomerUpdatedEvent(
+            (string) $this->faker->ulid(),
+            $this->faker->email()
+        ))->eventId();
+
+        self::assertStringStartsWith('customer_updated_', $eventId);
+        self::assertMatchesRegularExpression(
+            '/^customer_updated_[0-9a-f]{32}$/',
+            $eventId
+        );
+    }
+
+    public function testGeneratedEventIdsAreUnique(): void
+    {
+        $ids = [];
+        for ($i = 0; $i < 1000; ++$i) {
+            $ids[] = (new CustomerUpdatedEvent(
+                (string) $this->faker->ulid(),
+                $this->faker->email()
+            ))->eventId();
+        }
+
+        self::assertCount(1000, array_unique($ids));
+    }
 }


### PR DESCRIPTION
## What
Replaces predictable `uniqid('<prefix>_', true)` event-ID generation with `'<prefix>_' . bin2hex(random_bytes(16))` in all seven domain events.

## Why
CWE-330: `uniqid()` is time-based (microtime) and not cryptographically random, even with `more_entropy`. Event IDs were predictable and collision-prone under load. `random_bytes()` is CSPRNG-backed.

## Architecture constraints honored
- The events live in the **Domain layer**, which `deptrac.yaml` restricts to **zero external dependencies** (`Domain: []`). The fix therefore uses PHP builtins only — **no `Symfony\Component\Uid` import** (which would break deptrac). The existing prefix convention is preserved.
- No static methods added (the `generateEventId()` instance method is kept; only its body changed).
- Constructor `?string $eventId = null` override retained for tests/replay.

## Files
7 event classes + 4 unit test files (`CustomerCreated/Updated/Deleted` + `CustomerReferenceEvent` covering the type/status events).

## Tests (for 100% MSI)
Each new test asserts the id matches `/^<prefix>[0-9a-f]{32}$/` (kills byte-count + prefix mutations) and that 1000 generations are unique (kills constant-output mutations). Local: `php -l`, `php-cs-fixer`, `deptrac` (0 violations), and `phpunit` event tests (32 tests / 125 assertions) all pass.

> psalm/coverage/Infection weren't runnable in the sandbox (no pcov driver / fork-pool limitation); no new types/imports introduced, so relying on CI for those gates.

Closes #221

🤖 Generated as part of an autonomous penetration-test remediation sweep.

---
_Generated by [Claude Code](https://claude.ai/code/session_01D7yJf4tLNuFTSPDA3RBcTp)_

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch to CSPRNG-backed hex IDs for customer domain events and centralize ID generation in the `DomainEvent` base class, closing #221. Prevents predictability and collisions, keeps prefixes, and adds no new dependencies.

- **Bug Fixes**
  - Generate IDs with `bin2hex(random_bytes(16))` in all seven events.
  - Add tests for prefix + 32-char lowercase hex format and 1k-ID uniqueness.

- **Refactors**
  - Extract shared ID generation to `DomainEvent::generateEventId($prefix)`; events call `$this->generateEventId('<prefix>_')` and drop per-class methods.

<sup>Written for commit 5f06d4e7867f4ece4e8266bf9c480ae0aff95e92. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/VilnaCRM-Org/core-service/pull/228?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

