### PR TITLE
fix(security): gate destructive Schemathesis cleanup listener to non-production

### DIFF
--- a/config/services.yaml
+++ b/config/services.yaml
@@ -165,6 +165,12 @@ services:
           description: 'Seed schemathesis reference data.',
         }
 
+  # Schemathesis cleanup listener is gated to non-prod environments only (#223).
+  # The destructive customer cleanup never runs when kernel.environment is "prod".
+  App\Core\Customer\Infrastructure\EventListener\SchemathesisCleanupListener:
+    arguments:
+      $environment: '%kernel.environment%'
+
   # Base repository - used by API Platform for collections
   App\Core\Customer\Infrastructure\Repository\MongoCustomerRepository:
     public: true

--- a/src/Core/Customer/Infrastructure/EventListener/SchemathesisCleanupListener.php
+++ b/src/Core/Customer/Infrastructure/EventListener/SchemathesisCleanupListener.php
@@ -12,15 +12,22 @@ use Symfony\Component\HttpKernel\KernelEvents;
 #[AsEventListener(event: KernelEvents::TERMINATE)]
 final class SchemathesisCleanupListener
 {
+    private const PRODUCTION_ENVIRONMENT = 'prod';
+
     public function __construct(
         private readonly CustomerRepositoryInterface $customerRepository,
         private readonly SchemathesisCleanupEvaluator $evaluator,
-        private readonly SchemathesisEmailExtractor $emailExtractor
+        private readonly SchemathesisEmailExtractor $emailExtractor,
+        private readonly string $environment
     ) {
     }
 
     public function __invoke(TerminateEvent $event): void
     {
+        if ($this->environment === self::PRODUCTION_ENVIRONMENT) {
+            return;
+        }
+
         $request = $event->getRequest();
         $response = $event->getResponse();
 

--- a/tests/Unit/Core/Customer/Infrastructure/EventListener/SchemathesisCleanupListenerTest.php
+++ b/tests/Unit/Core/Customer/Infrastructure/EventListener/SchemathesisCleanupListenerTest.php
@@ -31,8 +31,38 @@ final class SchemathesisCleanupListenerTest extends UnitTestCase
         $this->listener = new SchemathesisCleanupListener(
             $this->customerRepository,
             $this->evaluator,
-            $this->emailExtractor
+            $this->emailExtractor,
+            'test'
         );
+    }
+
+    public function testInvokeSkipsCleanupInProductionEnvironment(): void
+    {
+        $listener = new SchemathesisCleanupListener(
+            $this->customerRepository,
+            $this->evaluator,
+            $this->emailExtractor,
+            'prod'
+        );
+
+        $kernel = $this->createMock(HttpKernelInterface::class);
+        $request = $this->createMock(Request::class);
+        $response = $this->createMock(Response::class);
+        $event = new TerminateEvent($kernel, $request, $response);
+
+        $this->evaluator
+            ->expects($this->never())
+            ->method('shouldCleanup');
+
+        $this->emailExtractor
+            ->expects($this->never())
+            ->method('extract');
+
+        $this->customerRepository
+            ->expects($this->never())
+            ->method('deleteByEmail');
+
+        $listener($event);
     }
 
     public function testInvokeSkipsWhenShouldNotCleanup(): void


### PR DESCRIPTION
## What
`SchemathesisCleanupListener` deletes customers on a header-gated `POST /api/customers` and was wired in **every** environment (plain `#[AsEventListener]`). This restricts it to **non-production** environments.

## Why
CWE-489 / CWE-749: a request header (`X-Schemathesis-Test: cleanup-customers`) toggled destructive deletion logic in production. Blast radius was limited (fires only for just-created emails on a successful POST), but a header-gated destructive hook should never ship to prod.

## Approach (B — env guard)
Inject `%kernel.environment%` and early-return when env is `prod`; the listener stays active in dev + test (Schemathesis runs in `test`). Chosen over test-only service registration because there is no `services_dev.yaml` and the goal is *non-production* (dev + test), and there was no existing tag-based schemathesis-service precedent to follow.

- `SchemathesisCleanupListener.php`: `string $environment` ctor arg + `PRODUCTION_ENVIRONMENT` guard (no static methods).
- `config/services.yaml`: explicit definition binding `$environment: '%kernel.environment%'` (attribute still provides the listener tag via autoconfigure).
- Test: added `testInvokeSkipsCleanupInProductionEnvironment` (asserts `deleteByEmail` never called under `prod`); existing non-prod tests unchanged.

## Validation
`php -l`, `php-cs-fixer`, `psalm` (listener: 0 errors), `phpunit` (4 tests/13 assertions), `deptrac` (0 violations) all pass locally. Coverage/Infection not runnable in sandbox (no pcov driver) — both branches are exercised so MSI should hold; relying on CI.

Closes #223

🤖 Generated as part of an autonomous penetration-test remediation sweep.

---
_Generated by [Claude Code](https://claude.ai/code/session_01D7yJf4tLNuFTSPDA3RBcTp)_

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restricts `SchemathesisCleanupListener` to non-production so header-gated customer cleanup never runs in `prod`. Meets #223 by disabling the destructive path in production while keeping it available in `dev` and `test`.

- **Bug Fixes**
  - Early return in `SchemathesisCleanupListener` when `%kernel.environment%` is `prod`.
  - Bound `$environment` via `config/services.yaml`.
  - Added `testInvokeSkipsCleanupInProductionEnvironment` to ensure no deletions occur in `prod`.

<sup>Written for commit 3301207f3903ffe4293331c86133c9162d86757c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/VilnaCRM-Org/core-service/pull/229?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

