### PR TITLE
fix(security): harden datastore port exposure and Mercure secret in compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,11 +16,11 @@ services:
       SERVER_NAME: ${SERVER_NAME:-localhost}, php:80
       DEFAULT_URI: https://${SERVER_NAME:-localhost}:${HTTPS_PORT:-443}
       HEALTHCHECK_URL: https://localhost/api/health
-      MERCURE_PUBLISHER_JWT_KEY: ${CADDY_MERCURE_JWT_SECRET:-!ChangeThisMercureHubJWTSecretKey!}
-      MERCURE_SUBSCRIBER_JWT_KEY: ${CADDY_MERCURE_JWT_SECRET:-!ChangeThisMercureHubJWTSecretKey!}
+      MERCURE_PUBLISHER_JWT_KEY: ${CADDY_MERCURE_JWT_SECRET:?CADDY_MERCURE_JWT_SECRET must be set}
+      MERCURE_SUBSCRIBER_JWT_KEY: ${CADDY_MERCURE_JWT_SECRET:?CADDY_MERCURE_JWT_SECRET must be set}
       MERCURE_URL: ${CADDY_MERCURE_URL:-http://localhost/.well-known/mercure}
       MERCURE_PUBLIC_URL: ${CADDY_MERCURE_PUBLIC_URL:-https://${SERVER_NAME:-localhost}:${HTTPS_PORT:-443}/.well-known/mercure}
-      MERCURE_JWT_SECRET: ${CADDY_MERCURE_JWT_SECRET:-!ChangeThisMercureHubJWTSecretKey!}
+      MERCURE_JWT_SECRET: ${CADDY_MERCURE_JWT_SECRET:?CADDY_MERCURE_JWT_SECRET must be set}
       DB_URL: mongodb://${DB_USER}:${DB_PASSWORD}@database:27017
       REDIS_URL: redis://redis:6379/0
       FRANKENPHP_LOOP_MAX: ${FRANKENPHP_LOOP_MAX:-500}
@@ -51,7 +51,7 @@ services:
       MONGO_INITDB_ROOT_USERNAME: ${DB_USER}
       MONGO_INITDB_ROOT_PASSWORD: ${DB_PASSWORD}
     ports:
-      - '${DB_PORT}:27017'
+      - '127.0.0.1:${DB_PORT}:27017'
     volumes:
       - db_data:/data/db
     healthcheck:
@@ -63,7 +63,7 @@ services:
   redis:
     image: redis:8.0.0-alpine
     ports:
-      - '${REDIS_PORT:-6379}:6379'
+      - '127.0.0.1:${REDIS_PORT:-6379}:6379'
 
 volumes:
   caddy_data:


### PR DESCRIPTION
## What
Two container-hygiene hardenings in `docker-compose.yml`:

1. **Datastore ports bound to loopback.** `${DB_PORT}:27017` → `127.0.0.1:${DB_PORT}:27017` and the Redis mapping likewise. Mongo (weak `root:secret`) and unauthenticated Redis are no longer published on all host interfaces (CWE-668).
2. **Mercure JWT secret fail-closed.** The publisher/subscriber/secret keys defaulted to the well-known placeholder `!ChangeThisMercureHubJWTSecretKey!`. Replaced with required `${CADDY_MERCURE_JWT_SECRET:?…}` so the stack refuses to start rather than signing Mercure JWTs with a publicly-known secret (CWE-798). `.env` still provides the value for local/CI, so `make start` is unaffected.

## Scope note (re: issue #220)
The issue also flagged `.env` being copied into the image. I intentionally **did not** add `.env` to `.dockerignore`: the prod build runs `composer dump-env prod` (`Dockerfile:86`) which requires `.env` to exist — excluding it breaks the build. The committed dev `APP_SECRET` is already overridden by runtime env in production; **rotating the committed secrets remains an operator follow-up** (can't be done safely in code).

## Validation
`docker compose config` and `docker compose -f docker-compose.yml -f docker-compose.override.yml config` both merge cleanly; ports render with `host_ip: 127.0.0.1`. Config-only.

Closes #220

🤖 Generated as part of an autonomous penetration-test remediation sweep.

---
_Generated by [Claude Code](https://claude.ai/code/session_01D7yJf4tLNuFTSPDA3RBcTp)_

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened `docker-compose.yml` by binding MongoDB and Redis ports to 127.0.0.1 and requiring a non-default Mercure JWT secret. Prevents accidental datastore exposure and blocks running with a public secret. Addresses #220.

- **Bug Fixes**
  - Bind MongoDB `27017` and Redis `6379` to `127.0.0.1` so they aren’t exposed on all interfaces.
  - Make `MERCURE_*_JWT_KEY` and `MERCURE_JWT_SECRET` require `CADDY_MERCURE_JWT_SECRET` (fail-closed if unset).

- **Migration**
  - Ensure `CADDY_MERCURE_JWT_SECRET` is set in your env. Local/CI is already covered via `.env`.

<sup>Written for commit 0ceadce53569dd71e2836e3465fc184bdab5d7b8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/VilnaCRM-Org/core-service/pull/230?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

