### PR TITLE
chore: ignore transient Claude Code agent worktrees

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,6 @@ summary.log
 .ralph/logs/
 _bmad/
 _bmad-output/
+
+# Claude Code agent worktrees (transient, harness-managed)
+/.claude/worktrees/


### PR DESCRIPTION
The .claude/worktrees/ directory holds harness-managed, auto-cleaned git
worktrees created by background agents; it should never be tracked.

https://claude.ai/code/session_01D7yJf4tLNuFTSPDA3RBcTp

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `/.claude/worktrees/` to `.gitignore` to ignore transient Claude Code agent worktrees. Prevents accidental commits of harness-managed worktrees and keeps diffs clean.

<sup>Written for commit 9e321390c140e57969736f0a51d5201670caa980. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/VilnaCRM-Org/core-service/pull/233?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

